### PR TITLE
Adds a function to the renderer to get the state and node IDs of the elements visible in the current viewport

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1282,6 +1282,16 @@ class SDFGRenderer {
         }
     }
 
+    visible_elements() {
+        let curx = this.canvas_manager.mapPixelToCoordsX(0);
+        let cury = this.canvas_manager.mapPixelToCoordsY(0);
+        let endx = this.canvas_manager.mapPixelToCoordsX(this.canvas.width);
+        let endy = this.canvas_manager.mapPixelToCoordsY(this.canvas.height);
+        let curw = endx - curx;
+        let curh = endy - cury;
+        return this.elements_in_rect(curx, cury, curw, curh);
+    }
+
     // Returns a dictionary of SDFG elements in a given rectangle. Used for
     // selection, rendering, localized transformations, etc.
     // The output is a dictionary of lists of dictionaries. The top-level keys are:

--- a/renderer.js
+++ b/renderer.js
@@ -1708,8 +1708,7 @@ class SDFGRenderer {
 
         if (dirty) {
             this.draw_async();
-            
-            // TODO: this is inefficient and causes lag. Do this better.
+
             // If a listener in VSCode is present, update it about the new
             // viewport and tell it to re-sort the shown transformations.
             if (vscode) {

--- a/renderer.js
+++ b/renderer.js
@@ -1289,15 +1289,15 @@ class SDFGRenderer {
         let endy = this.canvas_manager.mapPixelToCoordsY(this.canvas.height);
         let curw = endx - curx;
         let curh = endy - cury;
-        let elements_light = {
+        let elements = {
             states: [],
             nodes: [],
         };
         this.do_for_intersected_elements(curx, cury, curw, curh, (type, e, obj) => {
             if (type === 'nodes' || type === 'states')
-                elements_light[type].push(Number(e.id));
+                elements[type].push(Number(e.id));
         });
-        return elements_light;
+        return elements;
     }
 
     // Returns a dictionary of SDFG elements in a given rectangle. Used for


### PR DESCRIPTION
This is useful for sorting applicable transformations by relevance to the current viewport.