### PR TITLE
Generalizes the exit-preview method call to retrieve the current sdfg

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1040,7 +1040,7 @@ class SDFGRenderer {
             d.className = 'button hidden';
             if (vscode)
                 vscode.postMessage({
-                    type: 'exitPreview',
+                    type: 'getCurrentSdfg',
                 });
         };
         d.title = 'Exit preview';


### PR DESCRIPTION
This is a quickfix to adapt to a change made in the VSCode extension itself