### PR TITLE
Adds back the CSS and Markup for displaying code segments and objects in a more structured way

### DIFF
--- a/sdfg_utils.js
+++ b/sdfg_utils.js
@@ -118,15 +118,19 @@ function sdfg_property_to_string(prop, settings=null) {
             preview += sdfg_range_elem_to_string(range, settings) + ', ';
         }
         return preview.slice(0, -2) + ']';
-    } else if (prop.language !== undefined && prop.string_data !== undefined) {
+    } else if (prop.language !== undefined) {
         // Code
-        return '<pre class="w3-code">' + prop.string_data + '</pre>';
+        if (prop.string_data !== '' && prop.string_data !== undefined)
+            return '<pre class="code"><code>' + prop.string_data.trim() +
+                '</code></pre><div class="clearfix"></div>';
+        return '';
     } else if (prop.approx !== undefined && prop.main !== undefined) {
         // SymExpr
         return prop.main;
     } else if (prop.constructor == Object) {
         // General dictionary
-        return JSON.stringify(prop);
+        return '<pre class="code"><code>' + JSON.stringify(prop, undefined, 4) +
+            '</code></pre><div class="clearfix"></div>';
     } else if (prop.constructor == Array) {
         // General array
         let result = '[ ';

--- a/sdfv.css
+++ b/sdfv.css
@@ -34,6 +34,28 @@ h1,h2,h3,h4,h5,h6{font-family:"Segoe UI",Arial,sans-serif;font-weight:400;margin
     background-color: silver;
 }
 
+.clearfix {
+  clear: both;
+}
+
+pre.code {
+  margin-top: 0;
+  margin-bottom: 0;
+  display: block;
+  white-space: pre-wrap;
+}
+
+pre.code code {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-right: auto;
+  padding: .3rem;
+  display: block;
+  color: #966;
+  border-radius: 3px;
+  background-color: #eee;
+}
+
 .sidebar-inner {
   display: block;
   margin-left: 15px;

--- a/sdfv.js
+++ b/sdfv.js
@@ -273,7 +273,6 @@ function close_menu() {
 
 
 function init_menu() {
-    console.log('here');
     var right = document.getElementById('sidebar');
     var bar = document.getElementById('dragbar');
 


### PR DESCRIPTION
- This was previously a part of the SDFV clone in VSCode but was dropped with the move to a separate submodule