### PR TITLE
Provide a debug render mode, more intuitive box select, and optimizations in listing transformations

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1573,6 +1573,7 @@ class SDFGRenderer {
 
     on_mouse_event(event, comp_x_func, comp_y_func, evtype = "other") {
         let dirty = false; // Whether to redraw at the end
+        let resort_transform = false; // Whether to re-sort at the end
 
         if (evtype === "mousedown" || evtype === "touchstart") {
             this.drag_start = event;
@@ -1625,18 +1626,16 @@ class SDFGRenderer {
                         y_end: this.mousepos.y,
                     };
 
-                    // Mark for redraw and stop propagation
+                    // Mark for redraw and resort
                     dirty = true;
-                    this.draw_async();
-                    return false;
+                    resort_transform = true;
                 } else {
                     this.canvas_manager.translate(event.movementX,
                         event.movementY);
 
-                    // Mark for redraw
+                    // Mark for redraw and resort
                     dirty = true;
-                    this.draw_async();
-                    return false;
+                    resort_transform = true;
                 }
             } else {
                 this.drag_start = null;
@@ -1691,6 +1690,7 @@ class SDFGRenderer {
             let y = event.clientY - br.y;
             this.canvas_manager.scale(event.deltaY > 0 ? 0.9 : 1.1, x, y);
             dirty = true;
+            resort_transform = true;
         }
         // End of mouse-move/touch-based events
 
@@ -1770,6 +1770,7 @@ class SDFGRenderer {
                 // Re-layout SDFG
                 this.relayout();
                 dirty = true;
+                resort_transform = true;
             }
         }
 
@@ -1807,6 +1808,7 @@ class SDFGRenderer {
                     }
                     this.box_select_rect = null;
                     dirty = true;
+                    resort_transform = true;
                 }
             } else {
                 if (foreground_elem) {
@@ -1839,6 +1841,7 @@ class SDFGRenderer {
                     this.selected_elements = [];
                 }
                 dirty = true;
+                resort_transform = true;
             }
         }
         this.selected_elements.forEach((el) => {
@@ -1851,7 +1854,9 @@ class SDFGRenderer {
 
         if (dirty) {
             this.draw_async();
+        }
 
+        if (resort_transform) {
             // If a listener in VSCode is present, update it about the new
             // viewport and tell it to re-sort the shown transformations.
             try {

--- a/renderer.js
+++ b/renderer.js
@@ -896,7 +896,8 @@ function relayout_state(ctx, sdfg_state, sdfg, sdfg_list, state_parent_list) {
 }
 
 class SDFGRenderer {
-    constructor(sdfg, container, on_mouse_event = null, user_transform = null) {
+    constructor(sdfg, container, on_mouse_event = null, user_transform = null,
+                debug_draw = false) {
         // DIODE/SDFV-related fields
         this.sdfg = sdfg;
         this.sdfg_list = {};
@@ -932,6 +933,9 @@ class SDFGRenderer {
         // Selection related fields
         this.selected_elements = [];
 
+        // Draw debug aids.
+        this.debug_draw = debug_draw;
+
         this.init_elements(user_transform);
     }
 
@@ -958,6 +962,21 @@ class SDFGRenderer {
         this.canvas = document.createElement('canvas');
         this.canvas.style = 'background-color: inherit';
         this.container.append(this.canvas);
+
+        if (this.debug_draw) {
+            this.dbg_info_box = document.createElement('div');
+            this.dbg_info_box.style =
+                'position: absolute;' +
+                'bottom: .5rem;' +
+                'right: .5rem;' +
+                'background-color: black;' +
+                'padding: .3rem';
+            this.dbg_mouse_coords = document.createElement('span');
+            this.dbg_mouse_coords.style = 'color: white; font-size: 1rem;';
+            this.dbg_mouse_coords.innerText = 'x: N/A / y: N/A';
+            this.dbg_info_box.appendChild(this.dbg_mouse_coords);
+            this.container.appendChild(this.dbg_info_box);
+        }
 
         // Add buttons
         this.toolbar = document.createElement('div');
@@ -1262,6 +1281,32 @@ class SDFGRenderer {
         });
     }
 
+    // Draw a debug grid on the canvas to indicate coordinates.
+    debug_draw_grid(curx, cury, endx, endy, grid_width = 100) {
+        var lim_x_min = Math.floor(curx / grid_width) * grid_width;
+        var lim_x_max = Math.ceil(endx / grid_width) * grid_width;
+        var lim_y_min = Math.floor(cury / grid_width) * grid_width;
+        var lim_y_max = Math.ceil(endy / grid_width) * grid_width;
+        for (var i = lim_x_min; i <= lim_x_max; i += grid_width) {
+            this.ctx.moveTo(i, lim_y_min);
+            this.ctx.lineTo(i, lim_y_max);
+        }
+        for (var i = lim_y_min; i <= lim_y_max; i += grid_width) {
+            this.ctx.moveTo(lim_x_min, i);
+            this.ctx.lineTo(lim_x_max, i);
+        }
+        this.ctx.strokeStyle = 'yellow';
+        this.ctx.stroke();
+
+        // Draw the zero-point.
+        this.ctx.beginPath();
+        this.ctx.arc(0, 0, 10, 0, 2 * Math.PI, false);
+        this.ctx.fillStyle = 'red';
+        this.ctx.fill();
+        this.ctx.strokeStyle = 'red';
+        this.ctx.stroke();
+    }
+
     // Render SDFG
     draw(dt) {
         let ctx = this.ctx;
@@ -1276,7 +1321,7 @@ class SDFGRenderer {
 
         this.on_pre_draw();
 
-        draw_sdfg(this, ctx, g, this.mousepos);
+        draw_sdfg(this, ctx, g, this.mousepos, this.debug_draw);
 
         if (this.box_select_rect) {
             this.ctx.beginPath();
@@ -1289,6 +1334,16 @@ class SDFGRenderer {
                 this.box_select_rect.y_end - this.box_select_rect.y_start);
             this.ctx.stroke();
             this.ctx.setLineDash([]);
+        }
+
+        if (this.debug_draw) {
+            this.debug_draw_grid(curx, cury, endx, endy, 100);
+            if (this.mousepos) {
+                this.dbg_mouse_coords.innerText = 'x: ' + Math.floor(this.mousepos.x) +
+                    ' / y: ' + Math.floor(this.mousepos.y);
+            } else {
+                this.dbg_mouse_coords.innerText = 'x: N/A / y: N/A';
+            }
         }
 
         this.on_post_draw();
@@ -1795,7 +1850,10 @@ class SDFGRenderer {
                     let w = end_x - start_x;
                     let h = end_y - start_y;
                     this.do_for_intersected_elements(start_x, start_y, w, h,
-                        (type, e, obj) => elements_in_selection.push(obj));
+                        (type, e, obj) => {
+                            if (obj.contained_in(start_x, start_y, w, h))
+                                elements_in_selection.push(obj);
+                        });
                     if (event.shiftKey) {
                         elements_in_selection.forEach((el) => {
                             if (!this.selected_elements.includes(el))

--- a/renderer.js
+++ b/renderer.js
@@ -1629,7 +1629,8 @@ class SDFGRenderer {
 
     on_mouse_event(event, comp_x_func, comp_y_func, evtype = "other") {
         let dirty = false; // Whether to redraw at the end
-        let resort_transform = false; // Whether to re-sort at the end
+        // Whether the set of visible or selected elements changed
+        let element_focus_changed = false;
 
         if (evtype === "mousedown" || evtype === "touchstart") {
             this.drag_start = event;
@@ -1684,14 +1685,14 @@ class SDFGRenderer {
 
                     // Mark for redraw and resort
                     dirty = true;
-                    resort_transform = true;
+                    element_focus_changed = true;
                 } else {
                     this.canvas_manager.translate(event.movementX,
                         event.movementY);
 
                     // Mark for redraw and resort
                     dirty = true;
-                    resort_transform = true;
+                    element_focus_changed = true;
                 }
             } else {
                 this.drag_start = null;
@@ -1746,7 +1747,7 @@ class SDFGRenderer {
             let y = event.clientY - br.y;
             this.canvas_manager.scale(event.deltaY > 0 ? 0.9 : 1.1, x, y);
             dirty = true;
-            resort_transform = true;
+            element_focus_changed = true;
         }
         // End of mouse-move/touch-based events
 
@@ -1826,7 +1827,7 @@ class SDFGRenderer {
                 // Re-layout SDFG
                 this.relayout();
                 dirty = true;
-                resort_transform = true;
+                element_focus_changed = true;
             }
         }
 
@@ -1867,7 +1868,7 @@ class SDFGRenderer {
                     }
                     this.box_select_rect = null;
                     dirty = true;
-                    resort_transform = true;
+                    element_focus_changed = true;
                 }
             } else {
                 if (foreground_elem) {
@@ -1900,7 +1901,7 @@ class SDFGRenderer {
                     this.selected_elements = [];
                 }
                 dirty = true;
-                resort_transform = true;
+                element_focus_changed = true;
             }
         }
         this.selected_elements.forEach((el) => {
@@ -1915,7 +1916,7 @@ class SDFGRenderer {
             this.draw_async();
         }
 
-        if (resort_transform) {
+        if (element_focus_changed) {
             // If a listener in VSCode is present, update it about the new
             // viewport and tell it to re-sort the shown transformations.
             try {

--- a/renderer.js
+++ b/renderer.js
@@ -1850,7 +1850,7 @@ class SDFGRenderer {
 
         if (this.external_mouse_handler)
             dirty |= this.external_mouse_handler(evtype, event, { x: comp_x_func(event), y: comp_y_func(event) }, elements,
-                this, foreground_elem, ends_drag);
+                this, this.selected_elements, ends_drag);
 
         if (dirty) {
             this.draw_async();

--- a/renderer_elements.js
+++ b/renderer_elements.js
@@ -147,6 +147,18 @@ class State extends SDFGElement {
             ctx.strokeRect(clamped.x, clamped.y, clamped.w, clamped.h);
         }
 
+        // If collapsed, draw a "+" sign in the middle
+        if (this.data.state.attributes.is_collapsed) {
+            ctx.beginPath();
+            ctx.moveTo(this.x, this.y - LINEHEIGHT);
+            ctx.lineTo(this.x, this.y + LINEHEIGHT);
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.moveTo(this.x - LINEHEIGHT, this.y);
+            ctx.lineTo(this.x + LINEHEIGHT, this.y);
+            ctx.stroke();
+        }
+
         ctx.strokeStyle = "black";
     }
 

--- a/renderer_elements.js
+++ b/renderer_elements.js
@@ -19,18 +19,20 @@ class SDFGElement {
         this.height = this.data.layout.height;
     }
 
-    draw(renderer, ctx, mousepos, debug_draw = false) {}
+    draw(renderer, ctx, mousepos) {}
 
-    debug_draw(renderer, ctx, mousepos) {
-        // Print the center and bounding box in debug mode.
-        ctx.beginPath();
-        ctx.arc(this.x, this.y, 1, 0, 2 * Math.PI, false);
-        ctx.fillStyle = 'red';
-        ctx.fill();
-        ctx.strokeStyle = 'red';
-        ctx.stroke();
-        ctx.strokeRect(this.x - (this.width / 2.0), this.y - (this.height / 2.0),
-            this.width, this.height);
+    debug_draw(renderer, ctx) {
+        if (renderer.debug_draw) {
+            // Print the center and bounding box in debug mode.
+            ctx.beginPath();
+            ctx.arc(this.x, this.y, 1, 0, 2 * Math.PI, false);
+            ctx.fillStyle = 'red';
+            ctx.fill();
+            ctx.strokeStyle = 'red';
+            ctx.stroke();
+            ctx.strokeRect(this.x - (this.width / 2.0), this.y - (this.height / 2.0),
+                this.width, this.height);
+        }
     }
 
     attributes() {
@@ -115,7 +117,7 @@ class SDFG extends SDFGElement {
 }
 
 class State extends SDFGElement {
-    draw(renderer, ctx, mousepos, debug_draw = false) {
+    draw(renderer, ctx, mousepos) {
         let topleft = this.topleft();
         let visible_rect = renderer.visible_rect;
         let clamped = {x: Math.max(topleft.x, visible_rect.x),
@@ -146,12 +148,9 @@ class State extends SDFGElement {
         }
 
         ctx.strokeStyle = "black";
-
-        if (debug_draw)
-            super.debug_draw(renderer, ctx, mousepos, debug_draw);
     }
 
-    simple_draw(renderer, ctx, mousepos, debug_draw = false) {
+    simple_draw(renderer, ctx, mousepos) {
         // Fast drawing function for small states
         let topleft = this.topleft();
 
@@ -174,9 +173,6 @@ class State extends SDFGElement {
 
         ctx.font = oldfont;
         */
-
-        if (debug_draw)
-            super.debug_draw(renderer, ctx, mousepos);
     }
 
     tooltip(container) {
@@ -197,7 +193,7 @@ class State extends SDFGElement {
 }
 
 class Node extends SDFGElement {
-    draw(renderer, ctx, mousepos, debug_draw = false) {
+    draw(renderer, ctx, mousepos) {
         let topleft = this.topleft();
         ctx.fillStyle = "white";
         ctx.fillRect(topleft.x, topleft.y, this.width, this.height);
@@ -206,20 +202,14 @@ class Node extends SDFGElement {
         ctx.fillStyle = "black";
         let textw = ctx.measureText(this.label()).width;
         ctx.fillText(this.label(), this.x - textw / 2, this.y + LINEHEIGHT / 4);
-
-        if (debug_draw)
-            super.debug_draw(renderer, ctx, mousepos);
     }
 
-    simple_draw(renderer, ctx, mousepos, debug_draw = false) {
+    simple_draw(renderer, ctx, mousepos) {
         // Fast drawing function for small nodes
         let topleft = this.topleft();
         ctx.fillStyle = "white";
         ctx.fillRect(topleft.x, topleft.y, this.width, this.height);
         ctx.fillStyle = "black";
-
-        if (debug_draw)
-            super.debug_draw(renderer, ctx, mousepos);
     }
 
     label() {
@@ -241,7 +231,7 @@ class Node extends SDFGElement {
 }
 
 class Edge extends SDFGElement {
-    draw(renderer, ctx, mousepos, debug_draw = false) {
+    draw(renderer, ctx, mousepos) {
         let edge = this;
 
         ctx.beginPath();
@@ -286,9 +276,6 @@ class Edge extends SDFGElement {
 
         ctx.fillStyle = "black";
         ctx.strokeStyle = "black";
-
-        if (debug_draw)
-            super.debug_draw(renderer, ctx, mousepos);
     }
 
     tooltip(container, renderer) {
@@ -364,7 +351,7 @@ class Edge extends SDFGElement {
 }
 
 class Connector extends SDFGElement {
-    draw(renderer, ctx, mousepos, debug_draw = false) {
+    draw(renderer, ctx, mousepos) {
         let scope_connector = (this.data.name.startsWith("IN_") || this.data.name.startsWith("OUT_"));
         let topleft = this.topleft();
         ctx.beginPath();
@@ -400,9 +387,6 @@ class Connector extends SDFGElement {
         ctx.strokeStyle = "black";
         if (this.strokeStyle() !== 'black')
             renderer.tooltip = (c) => this.tooltip(c);
-
-        if (debug_draw)
-            super.debug_draw(renderer, ctx, mousepos);
     }
 
     attributes() {
@@ -422,7 +406,7 @@ class Connector extends SDFGElement {
 }
 
 class AccessNode extends Node {
-    draw(renderer, ctx, mousepos, debug_draw = false) {
+    draw(renderer, ctx, mousepos) {
         let topleft = this.topleft();
         ctx.beginPath();
         drawEllipse(ctx, topleft.x, topleft.y, this.width, this.height);
@@ -457,14 +441,11 @@ class AccessNode extends Node {
         ctx.fillStyle = "black";
         var textmetrics = ctx.measureText(this.label());
         ctx.fillText(this.label(), this.x - textmetrics.width / 2.0, this.y + LINEHEIGHT / 4.0);
-
-        if (debug_draw)
-            super.debug_draw(renderer, ctx, mousepos);
     }
 }
 
 class ScopeNode extends Node {
-    draw(renderer, ctx, mousepos, debug_draw = false) {
+    draw(renderer, ctx, mousepos) {
         let draw_shape;
         if (this.data.node.attributes.is_collapsed) {
             draw_shape = () => drawHexagon(ctx, this.x, this.y, this.width, this.height);
@@ -493,9 +474,6 @@ class ScopeNode extends Node {
             this.close_label(renderer), this.x, this.y,
             this.width, this.height,
             SCOPE_LOD);
-
-        if (debug_draw)
-            super.debug_draw(renderer, ctx, mousepos);
     }
 
     far_label() {
@@ -564,7 +542,7 @@ class EmptyTasklet extends Node {
 }
 
 class Tasklet extends Node {
-    draw(renderer, ctx, mousepos, debug_draw = false) {
+    draw(renderer, ctx, mousepos) {
         let topleft = this.topleft();
         drawOctagon(ctx, topleft, this.width, this.height);
         ctx.strokeStyle = this.strokeStyle();
@@ -613,14 +591,11 @@ class Tasklet extends Node {
 
         let textmetrics = ctx.measureText(this.label());
         ctx.fillText(this.label(), this.x - textmetrics.width / 2.0, this.y + LINEHEIGHT / 2.0);
-
-        if (debug_draw)
-            super.debug_draw(renderer, ctx, mousepos);
     }
 }
 
 class Reduce extends Node {
-    draw(renderer, ctx, mousepos, debug_draw = false) {
+    draw(renderer, ctx, mousepos) {
         let topleft = this.topleft();
         let draw_shape = () => {
             ctx.beginPath();
@@ -644,14 +619,11 @@ class Reduce extends Node {
             this.label(), this.x, this.y - this.height * 0.2,
             this.width, this.height,
             SCOPE_LOD);
-
-        if (debug_draw)
-            super.debug_draw(renderer, ctx, mousepos);
     }
 }
 
 class NestedSDFG extends Node {
-    draw(renderer, ctx, mousepos, debug_draw = false) {
+    draw(renderer, ctx, mousepos) {
         if (this.data.node.attributes.is_collapsed) {
             let topleft = this.topleft();
             drawOctagon(ctx, topleft, this.width, this.height);
@@ -672,11 +644,10 @@ class NestedSDFG extends Node {
         }
 
         // Draw square around nested SDFG
-        super.draw(renderer, ctx, mousepos, debug_draw);
-        // Debug draw already gets handled by the super.draw call.
+        super.draw(renderer, ctx, mousepos);
 
         // Draw nested graph
-        draw_sdfg(renderer, ctx, this.data.graph, mousepos, debug_draw);
+        draw_sdfg(renderer, ctx, this.data.graph, mousepos);
     }
 
     set_layout() {
@@ -726,7 +697,7 @@ class LibraryNode extends Node {
         ctx.lineTo(topleft.x + this.width, topleft.y + hexseg);
     }
 
-    draw(renderer, ctx, mousepos, debug_draw = false) {
+    draw(renderer, ctx, mousepos) {
         ctx.fillStyle = "white";
         this._path(ctx);
         ctx.fill();
@@ -738,22 +709,23 @@ class LibraryNode extends Node {
         ctx.fillStyle = "black";
         let textw = ctx.measureText(this.label()).width;
         ctx.fillText(this.label(), this.x - textw / 2, this.y + LINEHEIGHT / 4);
-
-        if (debug_draw)
-            super.debug_draw(renderer, ctx, mousepos);
     }
 }
 
 //////////////////////////////////////////////////////
 
 // Draw an entire SDFG
-function draw_sdfg(renderer, ctx, sdfg_dagre, mousepos, debug_draw = false) {
+function draw_sdfg(renderer, ctx, sdfg_dagre, mousepos) {
     let ppp = renderer.canvas_manager.points_per_pixel();
 
     // Render state machine
     let g = sdfg_dagre;
     if (!ctx.lod || ppp < EDGE_LOD)
-        g.edges().forEach(e => { g.edge(e).draw(renderer, ctx, mousepos, debug_draw); });
+        g.edges().forEach(e => {
+            let edge = g.edge(e);
+            edge.draw(renderer, ctx, mousepos);
+            edge.debug_draw(renderer, ctx);
+        });
 
 
     visible_rect = renderer.visible_rect;
@@ -763,14 +735,16 @@ function draw_sdfg(renderer, ctx, sdfg_dagre, mousepos, debug_draw = false) {
         let node = g.node(v);
 
         if (ctx.lod && (ppp >= STATE_LOD || node.width / ppp < STATE_LOD)) {
-            node.simple_draw(renderer, ctx, mousepos, debug_draw);
+            node.simple_draw(renderer, ctx, mousepos);
+            node.debug_draw(renderer, ctx);
             return;
         }
         // Skip invisible states
         if (ctx.lod && !node.intersect(visible_rect.x, visible_rect.y, visible_rect.w, visible_rect.h))
             return;
 
-        node.draw(renderer, ctx, mousepos, debug_draw);
+        node.draw(renderer, ctx, mousepos);
+        node.debug_draw(renderer, ctx);
 
         let ng = node.data.graph;
 
@@ -781,13 +755,21 @@ function draw_sdfg(renderer, ctx, sdfg_dagre, mousepos, debug_draw = false) {
                 if (ctx.lod && !n.intersect(visible_rect.x, visible_rect.y, visible_rect.w, visible_rect.h))
                     return;
                 if (ctx.lod && ppp >= NODE_LOD) {
-                    n.simple_draw(renderer, ctx, mousepos, debug_draw);
+                    n.simple_draw(renderer, ctx, mousepos);
+                    n.debug_draw(renderer, ctx);
                     return;
                 }
 
-                n.draw(renderer, ctx, mousepos, debug_draw);
-                n.in_connectors.forEach(c => { c.draw(renderer, ctx, mousepos, debug_draw); });
-                n.out_connectors.forEach(c => { c.draw(renderer, ctx, mousepos, debug_draw); });
+                n.draw(renderer, ctx, mousepos);
+                n.debug_draw(renderer, ctx);
+                n.in_connectors.forEach(c => {
+                    c.draw(renderer, ctx, mousepos);
+                    c.debug_draw(renderer, ctx);
+                });
+                n.out_connectors.forEach(c => {
+                    c.draw(renderer, ctx, mousepos);
+                    c.debug_draw(renderer, ctx);
+                });
             });
             if (ctx.lod && ppp >= EDGE_LOD)
                 return;
@@ -795,7 +777,8 @@ function draw_sdfg(renderer, ctx, sdfg_dagre, mousepos, debug_draw = false) {
                 let edge = ng.edge(e);
                 if (ctx.lod && !edge.intersect(visible_rect.x, visible_rect.y, visible_rect.w, visible_rect.h))
                     return;
-                ng.edge(e).draw(renderer, ctx, mousepos, debug_draw);
+                edge.draw(renderer, ctx, mousepos);
+                edge.debug_draw(renderer, ctx);
             });
         }
     });

--- a/sdfv.js
+++ b/sdfv.js
@@ -253,16 +253,26 @@ function outline(renderer, sdfg) {
     sidebar_show();
 }
 
-function mouse_event(evtype, event, mousepos, elements, renderer, elem,
-    ends_drag) {
+function mouse_event(evtype, event, mousepos, elements, renderer,
+    selected_elements, ends_drag) {
     if ((evtype === 'click' && !ends_drag) || evtype === 'dblclick') {
         if (renderer.menu)
             renderer.menu.destroy();
-        if (!elem)
-            elem = new SDFG(renderer.sdfg);
+        var element;
+        if (selected_elements.length === 0)
+            element = new SDFG(renderer.sdfg);
+        else if (selected_elements.length === 1)
+            element = selected_elements[0];
+        else
+            element = null;
             
-        sidebar_set_title(elem.type() + " " + elem.label());
-        fill_info(elem);
+        if (element !== null) {
+            sidebar_set_title(element.type() + " " + element.label());
+            fill_info(element);
+        } else {
+            close_menu();
+            sidebar_set_title("Multiple elements selected");
+        }
         sidebar_show();
         
     }

--- a/sdfv.js
+++ b/sdfv.js
@@ -4,7 +4,7 @@ var fr;
 var file = null;
 var renderer = null;
 
-function init_sdfv(sdfg, user_transform = null) {
+function init_sdfv(sdfg, user_transform = null, debug_draw = false) {
     $('input[type="file"]').change(function(e){
         if (e.target.files.length < 1)
             return;
@@ -34,7 +34,7 @@ function init_sdfv(sdfg, user_transform = null) {
 
     if (sdfg !== null)
         renderer = new SDFGRenderer(sdfg, document.getElementById('contents'),
-                                    mouse_event, user_transform);
+                                    mouse_event, user_transform, debug_draw);
 }
 
 function reload_file() {


### PR DESCRIPTION
- A boolean flag when initializing the SDFV can force SDFV to draw a coordinate-grid of configurable grid width over the SDFV canvas. Additionally, in that debug mode, mouse coordinates get printed to the bottom right of the canvas, and all elements draw their bounding boxes and center points.

- Box select behaves more intuitively by only selecting elements **INSIDE** the selection box, instead of all elements *intersecting* the bounding box.

- Transformations are not re-sorted every time the mouse moves. They are only re-sorted once the selection and/or viewport changes.

- The sidebar/info-box mentions when multiple elements are selected. This is to avoid ambiguity when selecting multiple elements, as it is otherwise unclear which element's information is being displayed.