### PR TITLE
Improve the renderer's user interface and remove CSS code duplication

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1469,7 +1469,6 @@ class SDFGRenderer {
         if (this.sdfg.error) {
             let error = this.sdfg.error;
 
-            // TODO:
             let type = '';
             let state_id = -1;
             let el_id = -1;

--- a/renderer.js
+++ b/renderer.js
@@ -980,6 +980,16 @@ class SDFGRenderer {
 
     // Updates buttons based on cursor mode
     update_toggle_buttons() {
+        // First clear out of all modes, then jump in to the correct mode.
+        this.selectmode_btn.innerHTML =
+            '<i class="material-icons">border_style</i>';
+        this.selectmode_btn.title = 'Enter box select mode';
+        this.movemode_btn.innerHTML =
+            '<i class="material-icons">open_with</i>';
+        this.movemode_btn.title = 'Enter object moving mode';
+        this.canvas.style.cursor = 'default';
+        this.interaction_info_text.innerHTML = '';
+
         switch (this.mouse_mode) {
             case 'move':
                 this.movemode_btn.innerHTML =
@@ -999,14 +1009,6 @@ class SDFGRenderer {
                 break;
             case 'pan':
             default:
-                this.selectmode_btn.innerHTML =
-                    '<i class="material-icons">border_style</i>';
-                this.selectmode_btn.title = 'Enter box select mode';
-                this.movemode_btn.innerHTML =
-                    '<i class="material-icons">open_with</i>';
-                this.movemode_btn.title = 'Enter object moving mode';
-                this.canvas.style.cursor = 'default';
-                this.interaction_info_text.innerHTML = '';
                 break;
         }
     }

--- a/renderer.js
+++ b/renderer.js
@@ -960,19 +960,19 @@ class SDFGRenderer {
     init_elements(user_transform) {
 
         this.canvas = document.createElement('canvas');
-        this.canvas.style = 'background-color: inherit';
+        this.canvas.style.backgroundColor = 'inherit';
         this.container.append(this.canvas);
 
         if (this.debug_draw) {
             this.dbg_info_box = document.createElement('div');
-            this.dbg_info_box.style =
-                'position: absolute;' +
-                'bottom: .5rem;' +
-                'right: .5rem;' +
-                'background-color: black;' +
-                'padding: .3rem';
+            this.dbg_info_box.style.position = 'absolute';
+            this.dbg_info_box.style.bottom = '.5rem';
+            this.dbg_info_box.style.right = '.5rem';
+            this.dbg_info_box.style.backgroundColor = 'black';
+            this.dbg_info_box.style.padding = '.3rem';
             this.dbg_mouse_coords = document.createElement('span');
-            this.dbg_mouse_coords.style = 'color: white; font-size: 1rem;';
+            this.dbg_mouse_coords.style.color = 'white';
+            this.dbg_mouse_coords.style.fontSize = '1rem';
             this.dbg_mouse_coords.innerText = 'x: N/A / y: N/A';
             this.dbg_info_box.appendChild(this.dbg_mouse_coords);
             this.container.appendChild(this.dbg_info_box);
@@ -1069,10 +1069,12 @@ class SDFGRenderer {
                 box_select_btn.innerHTML =
                     '<i class="material-icons">done</i>';
                 box_select_btn.title = 'Exit box select mode';
+                this.canvas.style.cursor = 'default';
             } else {
                 box_select_btn.innerHTML =
                     '<i class="material-icons">border_style</i>';
                 box_select_btn.title = 'Enter box select mode';
+                this.canvas.style.cursor = 'crosshair';
             }
         };
         box_select_btn.title = 'Enter box select mode';
@@ -1764,13 +1766,26 @@ class SDFGRenderer {
         let foreground_elem = elements_under_cursor.foreground_elem;
 
         // Change mouse cursor accordingly
-        if (total_elements > 0) {
-            if (this.move_mode && this.drag_start)
+        if (this.box_select_mode) {
+            this.canvas.style.cursor = 'crosshair';
+        } else if (total_elements > 0) {
+            if (this.move_mode && this.drag_start) {
                 this.canvas.style.cursor = 'grabbing';
-            else if (this.move_mode)
+            } else if (this.move_mode) {
                 this.canvas.style.cursor = 'grab';
-            else
-                this.canvas.style.cursor = 'pointer';
+            } else {
+                // Hovering over an element while not in any specific mode.
+                if ((foreground_elem.data.state &&
+                     foreground_elem.data.state.attributes.is_collapsed) ||
+                    (foreground_elem.data.node &&
+                     foreground_elem.data.node.attributes.is_collapsed)) {
+                    // This is a collapsed node or state, show with the cursor
+                    // shape that this can be expanded.
+                    this.canvas.style.cursor = 'alias';
+                } else {
+                    this.canvas.style.cursor = 'pointer';
+                }
+            }
         } else {
             this.canvas.style.cursor = 'auto';
         }

--- a/renderer.js
+++ b/renderer.js
@@ -978,6 +978,18 @@ class SDFGRenderer {
             this.container.appendChild(this.dbg_info_box);
         }
 
+        // Add an info box for interaction hints to the bottom left of the
+        // canvas.
+        this.interaction_info_box = document.createElement('div');
+        this.interaction_info_box.style.position = 'absolute';
+        this.interaction_info_box.style.bottom = '.5rem',
+        this.interaction_info_box.style.left = '.5rem',
+        this.interaction_info_box.style.padding = '.3rem';
+        this.interaction_info_text = document.createElement('span');
+        this.interaction_info_text.innerHTML = '';
+        this.interaction_info_box.appendChild(this.interaction_info_text);
+        this.container.appendChild(this.interaction_info_box);
+
         // Add buttons
         this.toolbar = document.createElement('div');
         this.toolbar.style = 'position:absolute; top:10px; left: 10px;';
@@ -1048,10 +1060,12 @@ class SDFGRenderer {
             if (this.move_mode) {
                 move_mode_btn.innerHTML = '<i class="material-icons">done</i>';
                 move_mode_btn.title = 'Exit object moving mode';
+                this.interaction_info_text.innerHTML = 'Middle Mouse: Pan view';
             } else {
                 move_mode_btn.innerHTML =
                     '<i class="material-icons">open_with</i>';
                 move_mode_btn.title = 'Enter object moving mode';
+                this.interaction_info_text.innerHTML = '';
             }
         };
         move_mode_btn.title = 'Enter object moving mode';
@@ -1069,12 +1083,17 @@ class SDFGRenderer {
                 box_select_btn.innerHTML =
                     '<i class="material-icons">done</i>';
                 box_select_btn.title = 'Exit box select mode';
-                this.canvas.style.cursor = 'default';
+                this.canvas.style.cursor = 'crosshair';
+                this.interaction_info_text.innerHTML =
+                    'Shift: Add to selection<br>' +
+                    'Ctrl: Remove from selection<br>' +
+                    'Middle Mouse: Pan view';
             } else {
                 box_select_btn.innerHTML =
                     '<i class="material-icons">border_style</i>';
                 box_select_btn.title = 'Enter box select mode';
-                this.canvas.style.cursor = 'crosshair';
+                this.canvas.style.cursor = 'default';
+                this.interaction_info_text.innerHTML = '';
             }
         };
         box_select_btn.title = 'Enter box select mode';
@@ -1650,10 +1669,10 @@ class SDFGRenderer {
             this.mousepos = { x: comp_x_func(event), y: comp_y_func(event) };
             this.realmousepos = { x: event.clientX, y: event.clientY };
 
+            // Only accept the primary mouse button as dragging source
             if (this.drag_start && event.buttons & 1) {
                 this.dragging = true;
 
-                // Only accept the primary mouse button as dragging source
                 if (this.move_mode) {
                     if (this.last_dragged_element) {
                         this.canvas.style.cursor = 'grabbing';
@@ -1696,6 +1715,12 @@ class SDFGRenderer {
                     dirty = true;
                     element_focus_changed = true;
                 }
+            } else if (this.drag_start && event.buttons & 4) {
+                // Pan the view with the middle mouse button
+                this.dragging = true;
+                this.canvas_manager.translate(event.movementX, event.movementY);
+                dirty = true;
+                element_focus_changed = true;
             } else {
                 this.drag_start = null;
                 if (event.buttons & 1 || event.buttons & 4)

--- a/sdfv.css
+++ b/sdfv.css
@@ -136,6 +136,21 @@ pre.code code {
   display: none;
 }
 
+.invalid_popup {
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  font-size: 1rem;
+  font-family: "Segoe UI", Arial, sans-serif;
+  padding: .2rem .4rem;
+  border-radius: 4px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: absolute;
+  display: none;
+}
+
 #contextmenu {
   position: absolute;
   background-color: #fdfdfd;

--- a/sdfv.css
+++ b/sdfv.css
@@ -1,41 +1,106 @@
-#contents {
-    position: relative;
-    resize: both;
-    width: 1024px;
-    height: 768px;
-    border: 1px solid;
-    overflow: auto;
+html {
+  height: 100%;
+  padding: 0;
 }
 
-/* Adapted from W3.CSS 4.13 June 2019 by Jan Egil and Borge Refsnes */
-html{-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}body{margin:0}
-h1,h2,h3,h4,h5,h6{font-family:"Segoe UI",Arial,sans-serif;font-weight:400;margin:10px 0}.w3-wide{letter-spacing:4px}
-.w3-button{border:none;display:inline-block;padding:8px 16px;vertical-align:middle;overflow:hidden;text-decoration:none;color:inherit;background-color:inherit;text-align:center;cursor:pointer;white-space:nowrap}
-.w3-button{-webkit-touch-callout:none;-webkit-user-select:none;-khtml-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
-.w3-button:disabled{cursor:not-allowed;opacity:0.3}.w3-disabled *,:disabled *{pointer-events:none}
-.w3-sidebar{height:100%;width:400px;background-color:#fff;position:fixed!important;z-index:1;overflow:auto;}
-.w3-bar-block .w3-dropdown-hover,.w3-bar-block .w3-dropdown-click{width:100%}
-.w3-bar-block .w3-dropdown-hover .w3-dropdown-content,.w3-bar-block .w3-dropdown-click .w3-dropdown-content{min-width:100%}
-.w3-bar-block .w3-dropdown-hover .w3-button,.w3-bar-block .w3-dropdown-click .w3-button{width:100%;text-align:left;padding:8px 16px}
-.w3-bar-block .w3-bar-item{width:100%;display:block;padding:8px 16px;text-align:left;border:none;white-space:normal;float:none;outline:0}
-.w3-code{font-family:Consolas,"courier new";font-size:14px;line-height: 20px}
-.w3-code{width:auto;background-color:#fff;padding:8px 12px;border-left:4px solid #4CAF50;word-wrap:break-word}
-.w3-card{box-shadow:0 2px 5px 0 rgba(0,0,0,0.16),0 2px 10px 0 rgba(0,0,0,0.12)}
-.w3-animate-right{position:relative;animation:animateright 0.4s}@keyframes animateright{from{right:-300px;opacity:0} to{right:0;opacity:1}}
-.w3-button:hover{color:#000!important;background-color:#ccc!important}
+body {
+  height: 100%;
+  margin: 0;
+  font-family: "Segoe UI", Arial, sans-serif;
+}
 
-.dragbar {
-    padding: 3px;
-    height: 100%;
-    width: 2px;
-    display: flex;
-    position: fixed;
-    cursor: col-resize;
-    background-color: silver;
+.hidden {
+  display: none;
 }
 
 .clearfix {
   clear: both;
+}
+
+#contents {
+  position: relative;
+  resize: both;
+  width: 1024px;
+  height: 768px;
+  border: 1px solid;
+  overflow: auto;
+}
+
+@keyframes animateright{
+  from{
+    right: -300px;
+    opacity:0;
+  }
+
+  to{
+    right:0;
+    opacity:1;
+  }
+}
+
+#sidebar {
+  height: 100%;
+  width: 400px;
+  background-color: #fff;
+  position: fixed !important;
+  z-index: 1;
+  overflow: auto;
+  box-shadow: 0 2px 5px 0 rgba(0,0,0,0.16), 0 2px 10px 0 rgba(0,0,0,0.12);
+  animation: animateright 0.4s;
+}
+
+#sidebar button {
+  cursor: pointer;
+  width: 100%;
+  display: block;
+  padding: 8px 16px;
+  text-align: left;
+  border: none;
+  white-space: normal;
+  float: none;
+  outline: 0;
+}
+
+#sidebar button:hover {
+  background-color: #ccc;
+}
+
+#sidebar .sidebar-inner {
+  display: block;
+  margin-left: 15px;
+}
+
+.dragbar {
+  padding: 3px;
+  height: 100%;
+  width: 2px;
+  display: flex;
+  position: fixed;
+  cursor: col-resize;
+  background-color: silver;
+}
+
+.button {
+  padding: .3rem .4rem;
+  border-radius: 5px;
+  cursor: pointer;
+  background-color: #eee;
+  color: black;
+}
+
+.button:hover {
+  background-color: #ccc;
+}
+
+.button > span {
+  margin: 0;
+}
+
+button {
+  border: 0;
+  margin: 2px;
+  background: none;
+  box-shadow: none;
 }
 
 pre.code {
@@ -56,54 +121,41 @@ pre.code code {
   background-color: #eee;
 }
 
-.sidebar-inner {
-  display: block;
-  margin-left: 15px;
+.sdfvtooltip {
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  font-size: 1rem;
+  font-family: "Segoe UI", Arial, sans-serif;
+  padding: .2rem .4rem;
+  border-radius: 4px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  position: absolute;
+  display: none;
 }
 
-.context_menu {
-    position: absolute;
-    background-color: #fdfdfd;
-    box-shadow: 0 4px 5px 3px rgba(0, 0, 0, 0.2);
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    z-index: 999;
+#contextmenu {
+  position: absolute;
+  background-color: #fdfdfd;
+  box-shadow: 0 4px 5px 3px rgba(0, 0, 0, 0.2);
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  z-index: 999;
 }
 
 .context_menu_option {
-    font-size: 14px;
-    font-family: "Segoe UI", Arial, sans-serif;
-    padding: 10px 40px 10px 20px;
-    cursor: pointer;
+  font-size: 1rem;
+  font-family: "Segoe UI", Arial, sans-serif;
+  padding: .5rem 2rem .5rem .4rem;
+  cursor: pointer;
 }
 
 .context_menu_option:hover {
-    background: rgba(0, 0, 0, 0.1);
-}
-
-.context_menu_option input {
-  position: absolute;
-  opacity: 0;
-  cursor: pointer;
-  height: 0;
-  width: 0;
-}
-
-.sdfvtooltip {
-    background: rgba(0, 0, 0, 0.8);
-    color: white;
-    font-size: 16px;
-    font-family: "Segoe UI", Arial, sans-serif;
-    padding: 2px 5px 2px 5px;
-    border-radius: 4px;
-    -webkit-user-select: none;
-    -moz-user-select: none;
-    -ms-user-select: none;
-    user-select: none;
-    position: absolute;
-    display: none;
+  background-color: rgba(0, 0, 0, 0.1);
 }
 
 /* Checkmarks for context menu items */
@@ -147,4 +199,3 @@ pre.code code {
   -ms-transform: rotate(45deg);
   transform: rotate(45deg);
 }
-

--- a/sdfv.js
+++ b/sdfv.js
@@ -230,31 +230,34 @@ function find_edge(state, edge_id) {
 }
 
 function find_graph_element(graph, type, sdfg_id, state_id=-1, el_id=-1) {
-    let requested_graph;
-    switch (type) {
-        case 'edge':
-            requested_graph = recursive_find_graph(graph, sdfg_id);
-            if (requested_graph) {
-                let state = find_state(requested_graph, state_id);
+    let requested_graph = recursive_find_graph(graph, sdfg_id);
+    let state;
+    if (requested_graph) {
+        switch (type) {
+            case 'edge':
+                state = find_state(requested_graph, state_id);
                 if (state)
                     return find_edge(state, el_id);
-            }
-            break;
-        case 'state':
-            requested_graph = recursive_find_graph(graph, sdfg_id);
-            if (requested_graph)
+                break;
+            case 'state':
                 return find_state(requested_graph, state_id);
-            break;
-        case 'node':
-            requested_graph = recursive_find_graph(graph, sdfg_id);
-            if (requested_graph) {
-                let state = find_state(requested_graph, state_id);
+            case 'node':
+                state = find_state(requested_graph, state_id);
                 if (state)
                     return find_node(state, el_id);
-            }
-            break;
-        default:
-            return undefined;
+                break;
+            case 'isedge':
+                let isedge = undefined;
+                Object.values(requested_graph._edgeLabels).forEach(ise => {
+                    if (ise.id === el_id) {
+                        isedge = ise;
+                        return isedge;
+                    }
+                });
+                return isedge;
+            default:
+                return undefined;
+        }
     }
     return undefined;
 }

--- a/sdfv.js
+++ b/sdfv.js
@@ -196,64 +196,61 @@ function recursive_find_graph(graph, sdfg_id) {
     return found;
 }
 
+function find_state(graph, state_id) {
+    let state = undefined;
+    graph.nodes().forEach(s_id => {
+        if (Number(s_id) === state_id) {
+            state = graph.node(s_id);
+            return state;
+        }
+    });
+    return state;
+}
+
+function find_node(state, node_id) {
+    let node = undefined;
+    state.data.graph.nodes().forEach(n_id => {
+        if (Number(n_id) === node_id) {
+            node = state.data.graph.node(n_id);
+            return node;
+        }
+    });
+    return node;
+}
+
+function find_edge(state, edge_id) {
+    let edge = undefined;
+    state.data.graph.edges().forEach(e_id => {
+        if (Number(e_id.name) === edge_id) {
+            edge = state.data.graph.edge(e_id);
+            return edge;
+        }
+    });
+    return edge;
+}
+
 function find_graph_element(graph, type, sdfg_id, state_id=-1, el_id=-1) {
     let requested_graph;
     switch (type) {
         case 'edge':
             requested_graph = recursive_find_graph(graph, sdfg_id);
             if (requested_graph) {
-                let state = undefined;
-                requested_graph.nodes().forEach(s_id => {
-                    if (Number(s_id) === state_id) {
-                        state = requested_graph.node(s_id);
-                        return;
-                    }
-                });
-                if (state) {
-                    let edge = undefined;
-                    state.data.graph.edges().forEach(e_id => {
-                        if (Number(e_id.name) === el_id) {
-                            edge = state.data.graph.edge(e_id);
-                            return;
-                        }
-                    });
-                    return edge;
-                }
+                let state = find_state(requested_graph, state_id);
+                if (state)
+                    return find_edge(state, el_id);
             }
             break;
         case 'state':
             requested_graph = recursive_find_graph(graph, sdfg_id);
-            if (requested_graph) {
-                let state = undefined;
-                requested_graph.nodes().forEach(s_id => {
-                    if (Number(s_id) === state_id) {
-                        state = requested_graph.node(s_id);
-                        return;
-                    }
-                });
-                return state;
-            }
+            if (requested_graph)
+                return find_state(requested_graph, state_id);
             break;
         case 'node':
             requested_graph = recursive_find_graph(graph, sdfg_id);
             if (requested_graph) {
-                let state = undefined;
-                requested_graph.nodes().forEach(s_id => {
-                    if (Number(s_id) === state_id) {
-                        state = requested_graph.node(s_id);
-                        return;
-                    }
-                });
-                if (state) {
-                    let node = undefined;
-                    state.data.graph.nodes().forEach(n_id => {
-                        if (Number(n_id) === el_id) {
-                            node = state.data.graph.node(n_id);
-                            return;
-                        }
-                    });
-                    return node;
-                }
+                let state = find_state(requested_graph, state_id);
+                if (state)
+                    return find_node(state, el_id);
             }
             break;
         default:

--- a/sdfv.js
+++ b/sdfv.js
@@ -180,6 +180,88 @@ function find_in_graph(renderer, sdfg, query, case_sensitive=false) {
     sidebar_show();
 }
 
+function recursive_find_graph(graph, sdfg_id) {
+    let found = undefined;
+    graph.nodes().forEach(n_id => {
+        let n = graph.node(n_id);
+        if (n && n.sdfg.sdfg_list_id === sdfg_id) {
+            found = graph;
+            return found;
+        } else if (n && n.data.graph) {
+            found = recursive_find_graph(n.data.graph, sdfg_id);
+            if (found)
+                return found;
+        }
+    });
+    return found;
+}
+
+function find_graph_element(graph, type, sdfg_id, state_id=-1, el_id=-1) {
+    let requested_graph;
+    switch (type) {
+        case 'edge':
+            requested_graph = recursive_find_graph(graph, sdfg_id);
+            if (requested_graph) {
+                let state = undefined;
+                requested_graph.nodes().forEach(s_id => {
+                    if (Number(s_id) === state_id) {
+                        state = requested_graph.node(s_id);
+                        return;
+                    }
+                });
+                if (state) {
+                    let edge = undefined;
+                    state.data.graph.edges().forEach(e_id => {
+                        if (Number(e_id.name) === el_id) {
+                            edge = state.data.graph.edge(e_id);
+                            return;
+                        }
+                    });
+                    return edge;
+                }
+            }
+            break;
+        case 'state':
+            requested_graph = recursive_find_graph(graph, sdfg_id);
+            if (requested_graph) {
+                let state = undefined;
+                requested_graph.nodes().forEach(s_id => {
+                    if (Number(s_id) === state_id) {
+                        state = requested_graph.node(s_id);
+                        return;
+                    }
+                });
+                return state;
+            }
+            break;
+        case 'node':
+            requested_graph = recursive_find_graph(graph, sdfg_id);
+            if (requested_graph) {
+                let state = undefined;
+                requested_graph.nodes().forEach(s_id => {
+                    if (Number(s_id) === state_id) {
+                        state = requested_graph.node(s_id);
+                        return;
+                    }
+                });
+                if (state) {
+                    let node = undefined;
+                    state.data.graph.nodes().forEach(n_id => {
+                        if (Number(n_id) === el_id) {
+                            node = state.data.graph.node(n_id);
+                            return;
+                        }
+                    });
+                    return node;
+                }
+            }
+            break;
+        default:
+            return undefined;
+    }
+    return undefined;
+}
+
 function outline(renderer, sdfg) {
     sidebar_set_title('SDFG Outline');
 


### PR DESCRIPTION
- Provide more descriptive cursor shapes based on possible graph/interface interactions
	- Show a crosshair in box select mode
	- Show an alias cursor when hovering over a collapsed element
- Provide a textual hint on what different keyboard and mouse buttons do in particular 'interaction modes'
- Merge the updated CSS from the embedded overwork of the webclient back into the SDFV's main CSS to remove code duplication
- Provide an error popover for invalid SDFGs
	- Zoom to the offending element(s)
	- Show an error popover describing the invalidity - this can be dismissed to continue working as usual
- Adapt the box select rectangle's line width to the current zoom level