### PR TITLE
Provide a static analysis overlay for FLOPS on SDFGs

### DIFF
--- a/overlay_manager.js
+++ b/overlay_manager.js
@@ -1,38 +1,8 @@
 // Copyright 2019-2020 ETH Zurich and the DaCe authors. All rights reserved.
 
-class GenericSdfgOverlay {
+class SymbolResolver {
 
-    static OVERLAY_TYPE = {
-        MEMORY_VOLUME: 'OVERLAY_TYPE_MEMORY_VOLUME',
-    };
-
-    constructor(renderer) {
-        this.renderer = renderer;
-    }
-
-    draw() {
-    }
-
-    on_mouse_event(type, ev, mousepos, elements, foreground_elem, ends_drag) {
-        return false;
-    }
-
-}
-
-class MemoryVolumeOverlay extends GenericSdfgOverlay {
-
-    static type = GenericSdfgOverlay.OVERLAY_TYPE.MEMORY_VOLUME;
-
-    constructor(renderer) {
-        super(renderer);
-
-        // Indicate which volume is considered 'maximum badness', meaning that
-        // the badness color scale tops out at this volume.
-        this.cutoff_high_volume = 10;
-        // The highest observed volume can be used to adjust the 'temperature'
-        // scale.
-        this.highest_observed_volume = 0;
-
+    constructor() {
         // Initialize an empty symbol - value mapping.
         this.symbol_value_map = {};
         this.symbols_to_define = [];
@@ -40,10 +10,54 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
         this.init_overlay_popup_dialogue();
     }
 
-    prompt_define_symbol() {
+    reset() {
+        this.symbol_value_map = {};
+        this.symbols_to_define = [];
+    }
+
+    parse_symbol_expression(expression_string, prompt_completion=false,
+        callback=undefined) {
+        let result = undefined;
+        try {
+            let expression_tree = math.parse(expression_string);
+            if (prompt_completion) {
+                this.recursive_find_undefined_symbol(expression_tree);
+                this.prompt_define_symbol(callback);
+            } else {
+                try {
+                    let evaluated =
+                        expression_tree.evaluate(this.symbol_value_map);
+                    if (evaluated !== undefined &&
+                        !isNaN(evaluated) &&
+                        Number.isInteger(+evaluated))
+                        result = +evaluated;
+                    else
+                        result = undefined;
+                } catch (e) {
+                    result = undefined;
+                }
+            }
+            return result;
+        } catch (exception) {
+            console.error(exception);
+        } finally {
+            return result;
+        }
+    }
+
+    prompt_define_symbol(callback=undefined) {
         if (this.symbols_to_define.length > 0) {
             let symbol = this.symbols_to_define.pop();
-            this.popup_dialogue._show(symbol, this.symbol_value_map);
+            let that = this;
+            this.popup_dialogue._show(
+                symbol,
+                this.symbol_value_map,
+                () => {
+                    if (callback !== undefined)
+                        callback();
+                    that.prompt_define_symbol(callback);
+                }
+            );
         }
     }
 
@@ -67,26 +81,6 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
                     break;
             }
         });
-    }
-
-    parse_volume(volume_string, prompt_completion=false) {
-        let expression_tree = math.parse(volume_string);
-        let volume = undefined;
-        if (prompt_completion) {
-            this.recursive_find_undefined_symbol(expression_tree);
-            this.prompt_define_symbol();
-        } else {
-            try {
-                let evaluation = expression_tree.evaluate(this.symbol_value_map);
-                if (evaluation && !isNaN(evaluation) && Number.isInteger(+evaluation))
-                    volume = +evaluation;
-                else
-                    volume = undefined;
-            } catch (e) {
-                volume = undefined;
-            }
-        }
-        return volume;
     }
 
     init_overlay_popup_dialogue() {
@@ -125,14 +119,14 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
         this.popup_dialogue._input = createElement('input', 'symbol_input',
             ['modal_input_text'], this.popup_dialogue._content);
         
-        let that = this;
         function set_val() {
             if (popup_dialogue._map && popup_dialogue._symbol) {
                 let val = popup_dialogue._input.value;
                 if (val && !isNaN(val) && Number.isInteger(+val) && val > 0) {
                     popup_dialogue._map[popup_dialogue._symbol] = val;
                     popup_dialogue._hide();
-                    that.prompt_define_symbol();
+                    if (popup_dialogue._callback)
+                        popup_dialogue._callback();
                     return;
                 }
             }
@@ -152,11 +146,12 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
         confirm_button_text.innerText = 'Confirm';
         createElement('div', '', ['clearfix'], footer_bar);
 
-        this.popup_dialogue._show = function (symbol, map) {
+        this.popup_dialogue._show = function (symbol, map, callback) {
             this.style.display = 'block';
             popup_dialogue._title.innerText = 'Define symbol ' + symbol;
             popup_dialogue._symbol = symbol;
             popup_dialogue._map = map;
+            popup_dialogue._callback = callback;
             dialogue_background._show();
         };
         this.popup_dialogue._hide = function () {
@@ -171,6 +166,297 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
         });
     }
 
+}
+
+class GenericSdfgOverlay {
+
+    static OVERLAY_TYPE = {
+        MEMORY_VOLUME: 'OVERLAY_TYPE_MEMORY_VOLUME',
+        STATIC_FLOPS: 'OVERLAY_TYPE_STATIC_FLOPS',
+    };
+
+    constructor(overlay_manager, renderer, type) {
+        this.overlay_manager = overlay_manager;
+        this.symbol_resolver = this.overlay_manager.symbol_resolver;
+        this.renderer = renderer;
+        this.type = type;
+    }
+
+    draw() {
+    }
+
+    on_mouse_event(type, ev, mousepos, elements, foreground_elem, ends_drag) {
+        return false;
+    }
+
+}
+
+class StaticFlopsOverlay extends GenericSdfgOverlay {
+
+    constructor(overlay_manager, renderer) {
+        super(
+            overlay_manager,
+            renderer,
+            GenericSdfgOverlay.OVERLAY_TYPE.STATIC_FLOPS
+        );
+
+        this.cutoff_high_flops = 10;
+        this.highest_observed_flops = 0;
+
+        this.flops_map = {};
+
+        if (vscode) {
+            vscode.postMessage({
+                type: 'getFlops',
+            });
+        }
+    }
+
+    get_element_uuid(element) {
+        let undefined_val = -1;
+        if (element instanceof State) {
+            return (
+                element.sdfg.sdfg_list_id + '/' +
+                element.id + '/' +
+                undefined_val + '/' +
+                undefined_val
+            );
+        } else if (element instanceof NestedSDFG) {
+            let sdfg_id = element.data.node.attributes.sdfg.sdfg_list_id;
+            return (
+                sdfg_id + '/' +
+                undefined_val + '/' +
+                undefined_val + '/' +
+                undefined_val
+            );
+        } else if (element instanceof MapExit) {
+            // For MapExit nodes, we want to get the uuid of the corresponding
+            // entry node instead, because the FLOPS count is held there.
+            return (
+                element.sdfg.sdfg_list_id + '/' +
+                element.parent_id + '/' +
+                element.data.node.scope_entry + '/' +
+                undefined_val
+            );
+        } else if (element instanceof Node) {
+            return (
+                element.sdfg.sdfg_list_id + '/' +
+                element.parent_id + '/' +
+                element.id + '/' +
+                undefined_val
+            );
+        }
+        return (
+            undefined_val + '/' +
+            undefined_val + '/' +
+            undefined_val + '/' +
+            undefined_val
+        );
+    }
+
+    clear_cached_flops_values() {
+        this.renderer.for_all_elements(0, 0, 0, 0, (type, e, obj, isected) => {
+            if (obj.data) {
+                if (obj.data.flops !== undefined)
+                    obj.data.flops = undefined;
+                if (obj.data.flops_string !== undefined)
+                    obj.data.flops_string = undefined;
+            }
+        });
+    }
+
+    calculate_flops_node(node) {
+        let flops_string = this.flops_map[this.get_element_uuid(node)];
+        let flops = undefined;
+        if (flops_string !== undefined)
+            flops = this.symbol_resolver.parse_symbol_expression(flops_string);
+
+        node.data.flops_string = flops_string;
+        node.data.flops = flops;
+
+        if (flops > this.highest_observed_flops)
+            this.highest_observed_flops = flops;
+
+        return flops;
+    }
+    
+    calculate_flops_graph(g) {
+        let that = this;
+        g.nodes().forEach(v => {
+            let state = g.node(v);
+            that.calculate_flops_node(state);
+            let state_graph = state.data.graph;
+            if (state_graph) {
+                state_graph.nodes().forEach(v => {
+                    let node = state_graph.node(v);
+                    that.calculate_flops_node(node);
+                    if (node instanceof NestedSDFG)
+                        that.calculate_flops_graph(node.data.graph);
+                });
+            }
+        });
+    }
+
+    recalculate_flops_values(graph) {
+        this.highest_observed_flops = 0;
+        this.calculate_flops_graph(graph);
+    }
+
+    update_flops_map(flops_map) {
+        this.flops_map = flops_map;
+
+        this.clear_cached_flops_values();
+        this.recalculate_flops_values(this.renderer.graph);
+
+        this.draw();
+    }
+
+    shade_node(node, ctx) {
+        let flops = node.data.flops;
+        let flops_string = node.data.flops_string;
+
+        if (flops_string !== undefined &&
+            this.renderer.mousepos !== undefined &&
+            node.intersect(this.renderer.mousepos.x, this.renderer.mousepos.y)) {
+            // Show the computed FLOPS value if applicable.
+            if (isNaN(flops_string) && flops !== undefined)
+                this.renderer.tooltip = () => {
+                    this.renderer.tooltip_container.innerText = (
+                        'FLOPS: ' + flops_string + ' (' + flops + ')'
+                    );
+                };
+            else
+                this.renderer.tooltip = () => {
+                    this.renderer.tooltip_container.innerText = (
+                        'FLOPS: ' + flops_string
+                    );
+                };
+        }
+
+        if (flops === undefined) {
+            // If the FLOPS can't be calculated, but there's an entry for this
+            // node's FLOPS, that means that there's an unresolved symbol. Shade
+            // the node grey to indicate that.
+            if (flops_string !== undefined) {
+                node.shade(this.renderer, ctx, 'gray');
+                return;
+            } else {
+                return;
+            }
+        }
+
+        // Only draw positive FLOPS.
+        if (flops <= 0)
+            return;
+
+        // Use either the default cutoff high value for FLOPS or the maximum
+        // observed one to calculate the 'badness' color.
+        let badness = (1 / Math.max(
+            this.cutoff_high_flops,
+            this.highest_observed_flops
+        )) * flops;
+        let color = getTempColor(badness);
+
+        node.shade(this.renderer, ctx, color);
+    }
+
+    recursively_shade_sdfg(graph, ctx, ppp, visible_rect) {
+        // First go over visible states, skipping invisible ones. We only draw
+        // something if the state is collapsed or we're zoomed out far enough.
+        // In that case, we draw the FLOPS calculated for the entire state.
+        // If it's expanded or zoomed in close enough, we traverse inside.
+        graph.nodes().forEach(v => {
+            let state = graph.node(v);
+
+            // If the node's invisible, we skip it.
+            if (ctx.lod && !state.intersect(visible_rect.x, visible_rect.y,
+                visible_rect.w, visible_rect.h))
+                return;
+
+            if ((ctx.lod && (ppp >= STATE_LOD ||
+                             state.width / ppp <= STATE_LOD)) ||
+                state.data.state.attributes.is_collapsed) {
+                this.shade_node(state, ctx);
+            } else {
+                let state_graph = state.data.graph;
+                if (state_graph) {
+                    state_graph.nodes().forEach(v => {
+                        let node = state_graph.node(v);
+
+                        // Skip the node if it's not visible.
+                        if (ctx.lod && !node.intersect(visible_rect.x,
+                            visible_rect.y, visible_rect.w, visible_rect.h))
+                            return;
+
+                        if (node.data.node.attributes.is_collapsed ||
+                            (ctx.lod && ppp >= NODE_LOD)) {
+                            this.shade_node(node, ctx);
+                        } else {
+                            if (node instanceof NestedSDFG) {
+                                this.recursively_shade_sdfg(
+                                    node.data.graph, ctx, ppp, visible_rect
+                                );
+                            } else {
+                                this.shade_node(node, ctx);
+                            }
+                        }
+                    });
+                }
+            }
+        });
+    }
+
+    draw() {
+        this.recursively_shade_sdfg(
+            this.renderer.graph,
+            this.renderer.ctx,
+            this.renderer.canvas_manager.points_per_pixel(),
+            this.renderer.visible_rect
+        );
+    }
+
+    on_mouse_event(type, ev, mousepos, elements, foreground_elem, ends_drag) {
+        if ((type === 'click' && !ends_drag) || type === 'dblclick') {
+            if (foreground_elem) {
+                // TODO: For collapsible elements, make sure to only fire it
+                // if the element is collapsed or we're zoomed out far enough
+                // that contents don't get rendered.
+                let flops_string = this.flops_map[
+                    this.get_element_uuid(foreground_elem)
+                ];
+                if (flops_string) {
+                    let that = this;
+                    this.symbol_resolver.parse_symbol_expression(
+                        flops_string, true, () => {
+                            that.clear_cached_flops_values();
+                            that.recalculate_flops_values(that.renderer.graph);
+                        }
+                    );
+                }
+            }
+        }
+        return false;
+    }
+
+}
+
+class MemoryVolumeOverlay extends GenericSdfgOverlay {
+
+    constructor(overlay_manager, renderer) {
+        super(
+            overlay_manager,
+            renderer,
+            GenericSdfgOverlay.OVERLAY_TYPE.MEMORY_VOLUME
+        );
+
+        // Indicate which volume is considered 'maximum badness', meaning that
+        // the badness color scale tops out at this volume.
+        this.cutoff_high_volume = 10;
+        // The highest observed volume can be used to adjust the 'temperature'
+        // scale.
+        this.highest_observed_volume = 0;
+    }
+
     draw() {
         this.renderer.for_all_elements(0, 0, 0, 0,
             (type, element, object, intersect) => {
@@ -183,40 +469,22 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
                     if (ctx.lod && ppp >= EDGE_LOD)
                         return;
 
+                    // Don't draw if the edge is outside the visible area.
+                    let visible_rect = this.renderer.visible_rect;
+                    if (!edge.intersect(visible_rect.x, visible_rect.y,
+                        visible_rect.w, visible_rect.h))
+                        return;
+
                     let volume = edge.attributes().volume;
                     if (volume !== undefined)
-                        volume = this.parse_volume(volume);
+                        volume = this.symbol_resolver.parse_symbol_expression(
+                            volume
+                        );
 
                     if (volume) {
                         // Update the highest obeserved volume if applicable.
                         if (volume > this.highest_observed_volume)
                             this.highest_observed_volume = volume;
-
-                        ctx.beginPath();
-                        ctx.moveTo(edge.points[0].x, edge.points[0].y);
-                        if (edge.points.length === 2) {
-                            ctx.lineTo(edge.points[1].x, edge.points[1].y);
-                        } else {
-                            let i;
-                            for (i = 1; i < edge.points.length - 2; i++) {
-                                let xm = (edge.points[i].x +
-                                    edge.points[i + 1].x) / 2.0;
-                                let ym = (edge.points[i].y +
-                                    edge.points[i + 1].y) / 2.0;
-                                ctx.quadraticCurveTo(edge.points[i].x,
-                                    edge.points[i].y, xm, ym);
-                            }
-                            ctx.quadraticCurveTo(edge.points[i].x,
-                                edge.points[i].y, edge.points[i + 1].x,
-                                edge.points[i + 1].y);
-                        }
-
-                        // Save the current stroke style, width, and opacity.
-                        let stroke_style = ctx.strokeStyle;
-                        let fill_style = ctx.fillStyle;
-                        let line_cap = ctx.lineCap;
-                        let line_width = ctx.lineWidth;
-                        let alpha = ctx.globalAlpha;
 
                         // Use either the default cutoff high volume, or the
                         // maximum observed volume to indicate the badness of
@@ -227,25 +495,7 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
                         )) * volume;
                         let color = getTempColor(badness);
 
-                        ctx.globalAlpha = '0.6';
-                        ctx.lineWidth = line_width + 1;
-                        ctx.fillStyle = color;
-                        ctx.strokeStyle = color;
-                        ctx.lineCap = 'round';
-
-                        ctx.stroke();
-
-                        if (edge.points.length < 2)
-                            return;
-                        drawArrow(ctx, edge.points[edge.points.length - 2],
-                            edge.points[edge.points.length - 1], 3, 0, 2);
-
-                        // Restore previous stroke style, width, and opacity.
-                        ctx.strokeStyle = stroke_style;
-                        ctx.fillStyle = fill_style;
-                        ctx.lineCap = line_cap;
-                        ctx.lineWidth = line_width;
-                        ctx.globalAlpha = alpha;
+                        edge.shade(this.renderer, ctx, color);
                     }
                 }
             }
@@ -257,7 +507,9 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
             if (foreground_elem && foreground_elem.data &&
                 foreground_elem.data.attributes &&
                 foreground_elem.data.attributes.volume) {
-                this.parse_volume(foreground_elem.data.attributes.volume, true);
+                this.symbol_resolver.parse_symbol_expression(
+                    foreground_elem.data.attributes.volume, true
+                );
             }
         }
         return false;
@@ -271,17 +523,26 @@ class OverlayManager {
         this.renderer = renderer;
 
         this.memory_volume_overlay_active = false;
+        this.static_flops_overlay_active = false;
 
         this.overlays = [];
+
+        this.symbol_resolver = new SymbolResolver();
     }
 
     register_overlay(type) {
         switch (type) {
             case GenericSdfgOverlay.OVERLAY_TYPE.MEMORY_VOLUME:
                 this.overlays.push(
-                    new MemoryVolumeOverlay(this.renderer)
+                    new MemoryVolumeOverlay(this, this.renderer)
                 );
                 this.memory_volume_overlay_active = true;
+                break;
+            case GenericSdfgOverlay.OVERLAY_TYPE.STATIC_FLOPS:
+                this.overlays.push(
+                    new StaticFlopsOverlay(this, this.renderer)
+                );
+                this.static_flops_overlay_active = true;
                 break;
             default:
                 break;
@@ -290,12 +551,15 @@ class OverlayManager {
 
     deregister_overlay(type) {
         this.overlays = this.overlays.filter(overlay => {
-            return overlay.type === type;
+            return overlay.type !== type;
         });
 
         switch (type) {
             case GenericSdfgOverlay.OVERLAY_TYPE.MEMORY_VOLUME:
                 this.memory_volume_overlay_active = false;
+                break;
+            case GenericSdfgOverlay.OVERLAY_TYPE.STATIC_FLOPS:
+                this.static_flops_overlay_active = false;
                 break;
             default:
                 break;

--- a/renderer.js
+++ b/renderer.js
@@ -1189,6 +1189,21 @@ class SDFGRenderer {
                                 that.draw_async();
                             }
                         );
+                        overlays_cmenu.addCheckableOption(
+                            'Static FLOPS analysis',
+                            that.overlay_manager.static_flops_overlay_active,
+                            (x, checked) => {
+                                if (checked)
+                                    that.overlay_manager.register_overlay(
+                                        GenericSdfgOverlay.OVERLAY_TYPE.STATIC_FLOPS
+                                    );
+                                else
+                                    that.overlay_manager.deregister_overlay(
+                                        GenericSdfgOverlay.OVERLAY_TYPE.STATIC_FLOPS
+                                    );
+                                that.draw_async();
+                            }
+                        );
                         that.overlays_menu = overlays_cmenu;
                         that.overlays_menu.show(rect.left, rect.top);
                     }


### PR DESCRIPTION
- Provide an additional overlay indicating FLOPS hotspots based on static analysis
- Provide a symbol resolver which is used to keep track of user defined values for specific symbols
- Provide a generic `shade` API for SDFG elements
  - Each SDFG element, in addition to being drawn, can with this be shaded in the post-draw call with a specified color and alpha value. This overlays the element with said color in the correct shape.