### PR TITLE
Highlight edges through nested SDFGs

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -2083,10 +2083,21 @@ class SDFGRenderer {
                     }
                 });
             }
+            
+            // Highlight all access nodes with the same name in the same nested sdfg
+            if (intersected && obj instanceof AccessNode) {
+                this.for_all_elements(0, 0, 0, 0, (type, e, sobj, intersected) => {
+                    if (sobj instanceof AccessNode && sobj.data.node.label == obj.data.node.label && sobj.sdfg.sdfg_list_id == obj.sdfg.sdfg_list_id) {
+                        sobj.highlighted = true;
+                    }
+                });
+            }
 
             if (intersected)
                 obj.hovered = true;
         });
+
+
 
         if (evtype === "mousemove") {
             // TODO: Draw only if elements have changed

--- a/renderer.js
+++ b/renderer.js
@@ -2092,34 +2092,35 @@ class SDFGRenderer {
             
             // Highlight all access nodes with the same name in the same nested sdfg
             if (intersected && obj instanceof AccessNode) {
-                this.for_all_elements(0, 0, 0, 0, (type, e, sobj, intersected) => {
-                    if (sobj instanceof AccessNode && sobj.data.node.label == obj.data.node.label && sobj.sdfg.sdfg_list_id == obj.sdfg.sdfg_list_id) {
-                        sobj.highlighted = true;
+                traverse_sdfg_scopes(this.sdfg_list[obj.sdfg.sdfg_list_id], (node) => {
+                    // If node is a state, then visit sub-scope
+                    if (node instanceof State) {
+                        return true;
                     }
+                    if (node instanceof AccessNode && node.data.node.label === obj.data.node.label) {
+                        node.highlighted = true;
+                    }
+                    // No need to visit sub-scope
+                    return false;
                 });
             }
 
             // Highlight all access nodes with the same name as the hovered connector in the nested sdfg
             if (intersected && obj instanceof Connector) {
-                this.for_all_elements(0, 0, 0, 0, (type, e, sobj, intersected) => {
-                    if (sobj instanceof NestedSDFG && sobj.id == obj.parent_id) {
-                        let nested_graph = sobj.data.graph;
-                        
-                        nested_graph.nodes().forEach( state_id => {
-                            let state = nested_graph.node(state_id);
-                            if (state) {
-                                let s_graph = state.data.graph;
-                                
-                                s_graph.nodes().forEach( node_id => {
-                                    let node = s_graph.node(node_id);
-                                    if (node instanceof AccessNode && node.data.node.label == obj.label()) {
-                                        node.highlighted = true;
-                                    }
-                                });
-                            }
-                        });
-                    }
-                });
+                let nested_graph = e.graph.node(obj.parent_id).data.graph;
+                if (nested_graph) {
+                    traverse_sdfg_scopes(nested_graph, (node) => {
+                        // If node is a state, then visit sub-scope
+                        if (node instanceof State) {
+                            return true;
+                        }
+                        if (node instanceof AccessNode && node.data.node.label === obj.label()) {
+                            node.highlighted = true;
+                        }
+                        // No need to visit sub-scope
+                        return false;
+                    });
+                }
             }
 
             if (intersected)

--- a/renderer.js
+++ b/renderer.js
@@ -2093,6 +2093,29 @@ class SDFGRenderer {
                 });
             }
 
+            // Highlight all access nodes with the same name as the hovered connector in the nested sdfg
+            if (intersected && obj instanceof Connector) {
+                this.for_all_elements(0, 0, 0, 0, (type, e, sobj, intersected) => {
+                    if (sobj instanceof NestedSDFG && sobj.id == obj.parent_id) {
+                        let nested_graph = sobj.data.graph;
+                        
+                        nested_graph.nodes().forEach( state_id => {
+                            let state = nested_graph.node(state_id);
+                            if (state) {
+                                let s_graph = state.data.graph;
+                                
+                                s_graph.nodes().forEach( node_id => {
+                                    let node = s_graph.node(node_id);
+                                    if (node instanceof AccessNode && node.data.node.label == obj.label()) {
+                                        node.highlighted = true;
+                                    }
+                                });
+                            }
+                        });
+                    }
+                });
+            }
+
             if (intersected)
                 obj.hovered = true;
         });

--- a/renderer.js
+++ b/renderer.js
@@ -1018,7 +1018,7 @@ class SDFGRenderer {
         this.selectmode_btn = null;
         
         // Memlet-Tree related fields
-        this.recompute_memlet_trees = true; 
+        this.all_memlet_trees = [];
         
         // View options
         this.inclusive_ranges = false;
@@ -1409,7 +1409,7 @@ class SDFGRenderer {
             this.state_parent_list);
         this.onresize();
 
-        this.recompute_memlet_trees = true;
+        this.all_memlet_trees = memlet_tree_complete(this.graph);
 
         return this.graph;
     }
@@ -1859,6 +1859,13 @@ class SDFGRenderer {
         traverse_recursive(this.graph, this.sdfg.attributes.name);
     }
 
+    get_nested_memlet_tree(edge) {
+        for (const tree of this.all_memlet_trees)
+            if (tree.has(edge))
+                return tree;
+        return [];
+    }
+
     find_elements_under_cursor(mouse_pos_x, mouse_pos_y) {
         // Find all elements under the cursor.
         const elements = this.elements_in_rect(mouse_pos_x, mouse_pos_y, 0, 0);
@@ -2081,8 +2088,7 @@ class SDFGRenderer {
         this.for_all_elements(this.mousepos.x, this.mousepos.y, 0, 0, (type, e, obj, intersected) => {
             // Highligh all edges of the memlet tree
             if (intersected && obj instanceof Edge && obj.parent_id != null) {
-                let tree = memlet_tree_complete(this.graph, obj, this.recompute_memlet_trees);
-                this.recompute_memlet_trees = false;
+                let tree = this.get_nested_memlet_tree(obj);
                 tree.forEach(te => {
                     if (te != obj) {
                         te.highlighted = true;

--- a/renderer.js
+++ b/renderer.js
@@ -2086,7 +2086,7 @@ class SDFGRenderer {
         });
         // Mark hovered and highlighted elements.
         this.for_all_elements(this.mousepos.x, this.mousepos.y, 0, 0, (type, e, obj, intersected) => {
-            // Highligh all edges of the memlet tree
+            // Highlight all edges of the memlet tree
             if (intersected && obj instanceof Edge && obj.parent_id != null) {
                 let tree = this.get_nested_memlet_tree(obj);
                 tree.forEach(te => {

--- a/renderer.js
+++ b/renderer.js
@@ -1017,7 +1017,9 @@ class SDFGRenderer {
         this.movemode_btn = null;
         this.selectmode_btn = null;
         
-
+        // Memlet-Tree related fields
+        this.recompute_memlet_trees = true; 
+        
         // View options
         this.inclusive_ranges = false;
 
@@ -1406,6 +1408,8 @@ class SDFGRenderer {
         this.graph = relayout_sdfg(this.ctx, this.sdfg, this.sdfg_list,
             this.state_parent_list);
         this.onresize();
+
+        this.recompute_memlet_trees = true;
 
         return this.graph;
     }
@@ -2075,8 +2079,10 @@ class SDFGRenderer {
         });
         // Mark hovered and highlighted elements.
         this.for_all_elements(this.mousepos.x, this.mousepos.y, 0, 0, (type, e, obj, intersected) => {
+            // Highligh all edges of the memlet tree
             if (intersected && obj instanceof Edge && obj.parent_id != null) {
-                let tree = memlet_tree(e.graph, obj);
+                let tree = memlet_tree_complete(this.graph, obj, this.recompute_memlet_trees);
+                this.recompute_memlet_trees = false;
                 tree.forEach(te => {
                     if (te != obj) {
                         te.highlighted = true;

--- a/sdfg_utils.js
+++ b/sdfg_utils.js
@@ -196,25 +196,142 @@ function traverse_sdfg_scopes(sdfg, func, post_subscope_func=null) {
     scopes_recursive(sdfg, sdfg.nodes());
 }
 
-// contains already visited edges to speed up computation of memlet trees
-var memlet_tree_edges_visited = [];
-
 /**
- * Returns a partial memlet tree from a given edge, from the given node 
+ * Returns a partial memlet tree from a given edge, from the root node
  * through all children (without siblings). Calling this function with
  * the root edge returns the entire memlet tree.
  **/
-function memlet_tree(graph, edge) {
-    if (memlet_tree_edges_visited.includes(edge)) {
-        return [];
-    }
-
-    memlet_tree_edges_visited.push(edge);
-
+function memlet_tree(graph, edge, root_only = false) {
     let result = [];
     let graph_edges = {};
     graph.edges().forEach(e => {
        graph_edges[e.name] = e;
+    });
+
+
+    function src(e) {
+        let ge = graph_edges[e.id];
+        return graph.node(ge.v);
+    }
+    function dst(e) {
+        let ge = graph_edges[e.id];
+        return graph.node(ge.w);
+    }
+
+    // Determine direction
+    let propagate_forward = false, propagate_backward = false;
+    if ((edge.src_connector && src(edge) instanceof EntryNode) ||
+        (edge.dst_connector && dst(edge) instanceof EntryNode &&
+         edge.dst_connector.startsWith('IN_')))
+        propagate_forward = true;
+    if ((edge.src_connector && src(edge) instanceof ExitNode) ||
+        (edge.dst_connector && dst(edge) instanceof ExitNode))
+        propagate_backward = true;
+
+    result.push(edge);
+
+    // If either both are false (no scopes involved) or both are true
+    // (invalid SDFG), we return only the current edge as a degenerate tree
+    if (propagate_forward == propagate_backward)
+        return result;
+
+    // Ascend (find tree root) while prepending
+    let curedge = edge;
+    if (propagate_forward) {
+        let source = src(curedge);
+        while(source instanceof EntryNode && curedge && curedge.src_connector) {
+            if (source.attributes().is_collapsed)
+                break;
+
+            let cname = curedge.src_connector.substring(4);  // Remove OUT_
+            curedge = null;
+            graph.inEdges(source.id).forEach(e => {
+                let ge = graph.edge(e);
+                if (ge.dst_connector == 'IN_' + cname)
+                    curedge = ge;
+            });
+            if (curedge) {
+                result.unshift(curedge);
+                source = src(curedge);
+            }
+        }
+    } else if (propagate_backward) {
+        let dest = dst(curedge);
+        while(dest instanceof ExitNode && curedge && curedge.dst_connector) {
+            let cname = curedge.dst_connector.substring(3);  // Remove IN_
+            curedge = null;
+            graph.outEdges(dest.id).forEach(e => {
+                let ge = graph.edge(e);
+                if (ge.src_connector == 'OUT_' + cname)
+                    curedge = ge;
+            });
+            if (curedge) {
+                result.unshift(curedge);
+                dest = dst(curedge);
+            }
+        }
+    }
+
+    if (root_only)
+        return [result[0]];
+
+    // Descend recursively
+    function add_children(edge) {
+        let children = [];
+        if (propagate_forward) {
+            let next_node = dst(edge);
+            if (!(next_node instanceof EntryNode) ||
+                    !edge.dst_connector || !edge.dst_connector.startsWith('IN_'))
+                return;
+            if (next_node.attributes().is_collapsed)
+                return;
+            let conn = edge.dst_connector.substring(3);
+            graph.outEdges(next_node.id).forEach(e => {
+                let ge = graph.edge(e);
+                if (ge.src_connector == 'OUT_' + conn) {
+                    children.push(ge);
+                    result.push(ge);
+                }
+            });
+        } else if (propagate_backward) {
+            let next_node = src(edge);
+            if (!(next_node instanceof ExitNode) || !edge.src_connector)
+                return;
+            let conn = edge.src_connector.substring(4);
+            graph.inEdges(next_node.id).forEach(e => {
+                let ge = graph.edge(e);
+                if (ge.dst_connector == 'IN_' + conn) {
+                    children.push(ge);
+                    result.push(ge);
+                }
+            });
+        }
+
+        for (let child of children)
+            add_children(child);
+    }
+
+    // Start from current edge
+    add_children(edge);
+
+    return result;
+}
+
+/**
+ * Returns a partial memlet tree from a given edge. It descends into nested SDFGs.
+ * @param visited_edges is used to speed up the computation of the memlet trees
+ **/
+function memlet_tree_nested(graph, edge, visited_edges = []) {
+    if (visited_edges.includes(edge)) {
+        return [];
+    }
+
+    visited_edges.push(edge);
+
+    let result = [];
+    let graph_edges = {};
+    graph.edges().forEach(e => {
+        graph_edges[e.name] = e;
     });
 
     function src(e) {
@@ -229,13 +346,13 @@ function memlet_tree(graph, edge) {
     // Determine direction
     let propagate_forward = false, propagate_backward = false;
     if ((edge.src_connector && src(edge) instanceof EntryNode) ||
-        (edge.dst_connector && dst(edge) instanceof EntryNode && 
-         edge.dst_connector.startsWith('IN_')) ||
-         dst(edge) instanceof NestedSDFG)
+        (edge.dst_connector && dst(edge) instanceof EntryNode &&
+            edge.dst_connector.startsWith('IN_')) ||
+        dst(edge) instanceof NestedSDFG)
         propagate_forward = true;
-    if ((edge.src_connector && src(edge) instanceof ExitNode) || 
+    if ((edge.src_connector && src(edge) instanceof ExitNode) ||
         (edge.dst_connector && dst(edge) instanceof ExitNode) ||
-         src(edge) instanceof NestedSDFG)
+        src(edge) instanceof NestedSDFG)
         propagate_backward = true;
 
     result.push(edge);
@@ -255,7 +372,7 @@ function memlet_tree(graph, edge) {
             if (next_node instanceof NestedSDFG) {
                 let nested_graph = next_node.data.graph;
                 let name = edge.dst_connector;
-                
+
                 nested_graph.nodes().forEach( state_id => {
                     let state = nested_graph.node(state_id);
                     if (!state) return;
@@ -265,15 +382,15 @@ function memlet_tree(graph, edge) {
 
                     s_graph.edges().forEach( e => {
                         let node = s_graph.node(e.v); // source
-                        if (node instanceof AccessNode && node.data.node.attributes.data == name) {
-                            result = result.concat(memlet_tree(s_graph, s_graph.edge(e)));
+                        if (node instanceof AccessNode && node.data.node.attributes.data === name) {
+                            result = result.concat(memlet_tree_nested(s_graph, s_graph.edge(e), visited_edges));
                         }
                     });
                 });
             }
 
             if (!(next_node instanceof EntryNode) ||
-                    !edge.dst_connector || !edge.dst_connector.startsWith('IN_'))
+                !edge.dst_connector || !edge.dst_connector.startsWith('IN_'))
                 return;
             if (next_node.attributes().is_collapsed)
                 return;
@@ -287,23 +404,23 @@ function memlet_tree(graph, edge) {
             });
         } else if (propagate_backward) {
             let next_node = src(edge);
-            
+
             // Descend into nested SDFG
             if (next_node instanceof NestedSDFG) {
                 let nested_graph = next_node.data.graph;
                 let name = edge.src_connector;
-                
+
                 nested_graph.nodes().forEach( state_id => {
                     let state = nested_graph.node(state_id);
                     if (!state) return;
-                    
+
                     let s_graph = state.data.graph;
                     if (!s_graph) return;
-                    
+
                     s_graph.edges().forEach( e => {
                         let node = s_graph.node(e.w); // destination
                         if (node instanceof AccessNode && node.data.node.attributes.data == name) {
-                            result = result.concat(memlet_tree(s_graph, s_graph.edge(e)));
+                            result = result.concat(memlet_tree_nested(s_graph, s_graph.edge(e)));
                         }
                     });
                 });
@@ -333,10 +450,13 @@ function memlet_tree(graph, edge) {
 }
 
 /**
- * Calls memlet_tree for every nested sdfg and its edges and returns a list with all memlet trees.
+ * Calls memlet_tree_nested for every nested SDFG and its edges and returns a list with all memlet trees.
+ * As edges are visited only in one direction (from outer SDFGs to inner SDFGs) a memlet can be split into several
+ * arrays.
  */
 function memlet_tree_recursive(root_graph) {
     let trees = [];
+    let visited_edges = [];
 
     root_graph.nodes().forEach( state_id => {
         let state = root_graph.node(state_id);
@@ -346,7 +466,7 @@ function memlet_tree_recursive(root_graph) {
         if (graph == null) return trees;
     
         graph.edges().forEach( e => {
-            let tree = memlet_tree(graph, graph.edge(e));
+            let tree = memlet_tree_nested(graph, graph.edge(e), visited_edges);
             if (tree.length > 1) {
                 trees.push(tree);
             }
@@ -367,48 +487,32 @@ function memlet_tree_recursive(root_graph) {
     return trees;
 }
 
-// Contains all the memlet trees after memlet_tree_complete has been called. They don't need to be recomputed.
-var all_memlet_trees = null;
-
 /**
- * Returns the memlet tree for the given edge.
+ * Returns all memlet trees as sets for the given graph.
  * 
  * @param {Graph} root_graph The top level graph.
- * @param {Edge} edge The edge that must be contained in the memlet tree.
- * @param {boolean} recompute_trees If set to true, then the memlets trees are recomputed. (Needed when the graph has changed...)
  */
-function memlet_tree_complete(root_graph, edge, recompute_trees = false) {
-    if (all_memlet_trees == null || recompute_trees) {
-        memlet_tree_edges_visited = [];
-        all_memlet_trees = [];
+function memlet_tree_complete(root_graph) {
+    let all_memlet_trees = [];
+    let memlet_trees = memlet_tree_recursive(root_graph);
 
-        let memlet_trees = memlet_tree_recursive(root_graph);
-
-        // combine trees as memlet_tree_recursive does not necessarily return the complete trees (they might be splitted into several trees)
-        memlet_trees.forEach( tree => {
-            common_edge = false;
-            for (mt of all_memlet_trees) {
-                for (edge of tree) {
-                    if (mt.has(edge)) {
-                        mt.add(...tree);
-                        common_edge = true;
-                        break;
-                    }
-                }
-                if (common_edge)
+    // combine trees as memlet_tree_recursive does not necessarily return the complete trees (they might be split into several trees)
+    memlet_trees.forEach( tree => {
+        let common_edge = false;
+        for (const mt of all_memlet_trees) {
+            for (const edge of tree) {
+                if (mt.has(edge)) {
+                    mt.add(...tree);
+                    common_edge = true;
                     break;
+                }
             }
-            if (!common_edge)
-                all_memlet_trees.push(new Set(tree));
-        })
-
-    }
-
-    for (tree of all_memlet_trees) {
-        if (tree.has(edge)) {
-            return tree;
+            if (common_edge)
+                break;
         }
-    }
+        if (!common_edge)
+            all_memlet_trees.push(new Set(tree));
+    })
 
-    return [];
+    return all_memlet_trees;
 }


### PR DESCRIPTION
- If an edge is hovered, then the memlet tree is highlighted through nested SDFGs.
- If a connector is hovered, the access nodes of the nested SDFG with the same name as the hovered connector are highlighted.
- If an access node is hovered, all the other access nodes with the same name in the same SDFG are highlighted.