### PR TITLE
Add integration for a separate symbol resolver in VSCode and fix various overlay bugs

### DIFF
--- a/overlay_manager.js
+++ b/overlay_manager.js
@@ -812,6 +812,12 @@ class OverlayManager {
         });
     }
 
+    refresh() {
+        this.overlays.forEach(overlay => {
+            overlay.refresh();
+        });
+    }
+
     on_mouse_event(type, ev, mousepos, elements, foreground_elem, ends_drag) {
         this.overlays.forEach(overlay => {
             overlay.on_mouse_event(type, ev, mousepos, elements,

--- a/overlay_manager.js
+++ b/overlay_manager.js
@@ -227,7 +227,7 @@ class StaticFlopsOverlay extends GenericSdfgOverlay {
 
         if (vscode) {
             vscode.postMessage({
-                type: 'getFlops',
+                type: 'dace.get_flops',
             });
         }
     }

--- a/overlay_manager.js
+++ b/overlay_manager.js
@@ -367,7 +367,11 @@ class StaticFlopsOverlay extends GenericSdfgOverlay {
                 this.badness_scale_center = math.mean(flops_values);
                 break;
             case 'mode':
-                this.badness_scale_center = math.mode(flops_values);
+                let mode = math.mode(flops_values);
+                if (Array.isArray(mode))
+                    this.badness_scale_center = mode[0];
+                else
+                    this.badness_scale_center = mode;
                 break;
             case 'median':
             default:
@@ -624,7 +628,11 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
                 this.badness_scale_center = math.mean(volume_values);
                 break;
             case 'mode':
-                this.badness_scale_center = math.mode(volume_values);
+                let mode = math.mode(volume_values);
+                if (Array.isArray(mode))
+                    this.badness_scale_center = mode[0];
+                else
+                    this.badness_scale_center = mode;
                 break;
             case 'median':
             default:

--- a/overlay_manager.js
+++ b/overlay_manager.js
@@ -2,31 +2,41 @@
 
 class SymbolResolver {
 
-    constructor() {
-        // Initialize an empty symbol - value mapping.
+    constructor(renderer) {
+        this.renderer = renderer;
+        this.sdfg = this.renderer.sdfg;
+
+        // Initialize the symbol mapping to the graph's symbol table.
         this.symbol_value_map = {};
+        Object.keys(this.sdfg.attributes.symbols).forEach((symbol) => {
+            this.symbol_value_map[symbol] = undefined;
+        });
         this.symbols_to_define = [];
 
         this.init_overlay_popup_dialogue();
     }
 
-    reset() {
-        this.symbol_value_map = {};
-        this.symbols_to_define = [];
+    symbol_value_changed(symbol, value) {
+        if (symbol in this.symbol_value_map)
+            this.symbol_value_map[symbol] = value;
     }
 
-    parse_symbol_expression(expression_string, prompt_completion=false,
-        callback=undefined) {
+    parse_symbol_expression(
+        expression_string,
+        mapping,
+        prompt_completion=false,
+        callback=undefined
+    ) {
         let result = undefined;
         try {
             let expression_tree = math.parse(expression_string);
             if (prompt_completion) {
-                this.recursive_find_undefined_symbol(expression_tree);
-                this.prompt_define_symbol(callback);
+                this.recursive_find_undefined_symbol(expression_tree, mapping);
+                this.prompt_define_symbol(mapping, callback);
             } else {
                 try {
                     let evaluated =
-                        expression_tree.evaluate(this.symbol_value_map);
+                        expression_tree.evaluate(mapping);
                     if (evaluated !== undefined &&
                         !isNaN(evaluated) &&
                         Number.isInteger(+evaluated))
@@ -45,27 +55,34 @@ class SymbolResolver {
         }
     }
 
-    prompt_define_symbol(callback=undefined) {
+    prompt_define_symbol(mapping, callback=undefined) {
         if (this.symbols_to_define.length > 0) {
             let symbol = this.symbols_to_define.pop();
             let that = this;
             this.popup_dialogue._show(
                 symbol,
-                this.symbol_value_map,
+                mapping,
                 () => {
+                    if (vscode)
+                        vscode.postMessage({
+                            type: 'symbol_resolver.define_symbol',
+                            symbol: symbol,
+                            definition: mapping[symbol],
+                        });
                     if (callback !== undefined)
                         callback();
-                    that.prompt_define_symbol(callback);
+                    that.prompt_define_symbol(mapping, callback);
                 }
             );
         }
     }
 
-    recursive_find_undefined_symbol(expression_tree) {
+    recursive_find_undefined_symbol(expression_tree, mapping) {
         expression_tree.forEach((node, path, parent) => {
             switch (node.type) {
                 case 'SymbolNode':
-                    if (!this.symbol_value_map[node.name] &&
+                    if (node.name in mapping &&
+                        mapping[node.name] === undefined &&
                         !this.symbols_to_define.includes(node.name)) {
                         // This is an undefined symbol.
                         // Ask for it to be defined.
@@ -74,7 +91,7 @@ class SymbolResolver {
                     break;
                 case 'OperatorNode':
                 case 'ParenthesisNode':
-                    this.recursive_find_undefined_symbol(node);
+                    this.recursive_find_undefined_symbol(node, mapping);
                     break;
                 default:
                     // Ignore
@@ -180,6 +197,9 @@ class GenericSdfgOverlay {
         this.symbol_resolver = this.overlay_manager.symbol_resolver;
         this.renderer = renderer;
         this.type = type;
+
+        this.badness_scale_method = 'median';
+        this.badness_scale_center = 5;
     }
 
     draw() {
@@ -187,6 +207,9 @@ class GenericSdfgOverlay {
 
     on_mouse_event(type, ev, mousepos, elements, foreground_elem, ends_drag) {
         return false;
+    }
+
+    refresh(){
     }
 
 }
@@ -199,9 +222,6 @@ class StaticFlopsOverlay extends GenericSdfgOverlay {
             renderer,
             GenericSdfgOverlay.OVERLAY_TYPE.STATIC_FLOPS
         );
-
-        this.cutoff_high_flops = 10;
-        this.highest_observed_flops = 0;
 
         this.flops_map = {};
 
@@ -265,50 +285,107 @@ class StaticFlopsOverlay extends GenericSdfgOverlay {
         });
     }
 
-    calculate_flops_node(node) {
+    calculate_flops_node(node, symbol_map, flops_values) {
         let flops_string = this.flops_map[this.get_element_uuid(node)];
         let flops = undefined;
         if (flops_string !== undefined)
-            flops = this.symbol_resolver.parse_symbol_expression(flops_string);
+            flops = this.symbol_resolver.parse_symbol_expression(
+                flops_string,
+                symbol_map
+            );
 
         node.data.flops_string = flops_string;
         node.data.flops = flops;
 
-        if (flops > this.highest_observed_flops)
-            this.highest_observed_flops = flops;
+        if (flops !== undefined && flops > 0)
+            flops_values.push(flops);
 
         return flops;
     }
     
-    calculate_flops_graph(g) {
+    calculate_flops_graph(g, symbol_map, flops_values) {
         let that = this;
         g.nodes().forEach(v => {
             let state = g.node(v);
-            that.calculate_flops_node(state);
+            that.calculate_flops_node(state, symbol_map, flops_values);
             let state_graph = state.data.graph;
             if (state_graph) {
                 state_graph.nodes().forEach(v => {
                     let node = state_graph.node(v);
-                    that.calculate_flops_node(node);
-                    if (node instanceof NestedSDFG)
-                        that.calculate_flops_graph(node.data.graph);
+                    if (node instanceof NestedSDFG) {
+                        let nested_symbols_map = {};
+                        let mapping = node.data.node.attributes.symbol_mapping;
+                        // Translate the symbol mappings for the nested SDFG
+                        // based on the mapping described on the node.
+                        Object.keys(mapping).forEach((symbol) => {
+                            nested_symbols_map[symbol] =
+                                that.symbol_resolver.parse_symbol_expression(
+                                    mapping[symbol],
+                                    symbol_map
+                                );
+                        });
+                        // Merge in the parent mappings.
+                        Object.keys(symbol_map).forEach((symbol) => {
+                            if (!(symbol in nested_symbols_map))
+                                nested_symbols_map[symbol] = symbol_map[symbol];
+                        });
+
+                        that.calculate_flops_node(
+                            node,
+                            nested_symbols_map,
+                            flops_values
+                        );
+                        that.calculate_flops_graph(
+                            node.data.graph,
+                            nested_symbols_map,
+                            flops_values
+                        );
+                    } else {
+                        that.calculate_flops_node(
+                            node,
+                            symbol_map,
+                            flops_values
+                        );
+                    }
                 });
             }
         });
     }
 
     recalculate_flops_values(graph) {
-        this.highest_observed_flops = 0;
-        this.calculate_flops_graph(graph);
+        this.badness_scale_center = 5;
+
+        let flops_values = [0];
+        this.calculate_flops_graph(
+            graph,
+            this.symbol_resolver.symbol_value_map,
+            flops_values
+        );
+
+        switch (this.badness_scale_method) {
+            case 'mean':
+                this.badness_scale_center = math.mean(flops_values);
+                break;
+            case 'mode':
+                this.badness_scale_center = math.mode(flops_values);
+                break;
+            case 'median':
+            default:
+                this.badness_scale_center = math.median(flops_values);
+                break;
+        }
     }
 
     update_flops_map(flops_map) {
         this.flops_map = flops_map;
+        this.refresh();
+    }
 
+    refresh() {
         this.clear_cached_flops_values();
         this.recalculate_flops_values(this.renderer.graph);
 
-        this.draw();
+        this.renderer.draw_async();
     }
 
     shade_node(node, ctx) {
@@ -349,12 +426,12 @@ class StaticFlopsOverlay extends GenericSdfgOverlay {
         if (flops <= 0)
             return;
 
-        // Use either the default cutoff high value for FLOPS or the maximum
-        // observed one to calculate the 'badness' color.
-        let badness = (1 / Math.max(
-            this.cutoff_high_flops,
-            this.highest_observed_flops
-        )) * flops;
+        // Calculate the 'badness' color.
+        let badness = (1 / (this.badness_scale_center * 2)) * flops;
+        if (badness < 0)
+            badness = 0;
+        if (badness > 1)
+            badness = 1;
         let color = getTempColor(badness);
 
         node.shade(this.renderer, ctx, color);
@@ -416,22 +493,27 @@ class StaticFlopsOverlay extends GenericSdfgOverlay {
     }
 
     on_mouse_event(type, ev, mousepos, elements, foreground_elem, ends_drag) {
-        if ((type === 'click' && !ends_drag) || type === 'dblclick') {
-            if (foreground_elem) {
-                // TODO: For collapsible elements, make sure to only fire it
-                // if the element is collapsed or we're zoomed out far enough
-                // that contents don't get rendered.
-                let flops_string = this.flops_map[
-                    this.get_element_uuid(foreground_elem)
-                ];
-                if (flops_string) {
-                    let that = this;
-                    this.symbol_resolver.parse_symbol_expression(
-                        flops_string, true, () => {
-                            that.clear_cached_flops_values();
-                            that.recalculate_flops_values(that.renderer.graph);
-                        }
-                    );
+        if (type === 'click' && !ends_drag) {
+            if (foreground_elem !== undefined && foreground_elem !== null &&
+                !(foreground_elem instanceof Edge)) {
+                if (foreground_elem.data.flops === undefined) {
+                    let flops_string = this.flops_map[
+                        this.get_element_uuid(foreground_elem)
+                    ];
+                    if (flops_string) {
+                        let that = this;
+                        this.symbol_resolver.parse_symbol_expression(
+                            flops_string,
+                            that.symbol_resolver.symbol_value_map,
+                            true,
+                            () => {
+                                that.clear_cached_flops_values();
+                                that.recalculate_flops_values(
+                                    that.renderer.graph
+                                );
+                            }
+                        );
+                    }
                 }
             }
         }
@@ -449,67 +531,211 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
             GenericSdfgOverlay.OVERLAY_TYPE.MEMORY_VOLUME
         );
 
-        // Indicate which volume is considered 'maximum badness', meaning that
-        // the badness color scale tops out at this volume.
-        this.cutoff_high_volume = 10;
-        // The highest observed volume can be used to adjust the 'temperature'
-        // scale.
-        this.highest_observed_volume = 0;
+        this.refresh();
+    }
+
+    clear_cached_volume_values() {
+        this.renderer.for_all_elements(0, 0, 0, 0, (type, e, obj, isected) => {
+            if (obj.data) {
+                if (obj.data.volume !== undefined)
+                    obj.data.volume = undefined;
+            }
+        });
+    }
+
+    calculate_volume_edge(edge, symbol_map, volume_values) {
+        let volume_string = undefined;
+        if (edge.data && edge.data.attributes)
+            volume_string = edge.data.attributes.volume;
+        let volume = undefined;
+        if (volume_string !== undefined)
+            volume = this.symbol_resolver.parse_symbol_expression(
+                volume_string,
+                symbol_map
+            );
+
+        edge.data.volume = volume;
+
+        if (volume !== undefined && volume > 0)
+                volume_values.push(volume);
+
+        return volume;
+    }
+
+    calculate_volume_graph(g, symbol_map, volume_values) {
+        let that = this;
+        g.nodes().forEach(v => {
+            let state = g.node(v);
+            let state_graph = state.data.graph;
+            if (state_graph) {
+                state_graph.edges().forEach(e => {
+                    let edge = state_graph.edge(e);
+                    if (edge instanceof Edge)
+                        that.calculate_volume_edge(
+                            edge,
+                            symbol_map,
+                            volume_values
+                        );
+                });
+
+                state_graph.nodes().forEach(v => {
+                    let node = state_graph.node(v);
+                    if (node instanceof NestedSDFG) {
+                        let nested_symbols_map = {};
+                        let mapping = node.data.node.attributes.symbol_mapping;
+                        // Translate the symbol mappings for the nested SDFG
+                        // based on the mapping described on the node.
+                        Object.keys(mapping).forEach((symbol) => {
+                            nested_symbols_map[symbol] =
+                                that.symbol_resolver.parse_symbol_expression(
+                                    mapping[symbol],
+                                    symbol_map
+                                );
+                        });
+                        // Merge in the parent mappings.
+                        Object.keys(symbol_map).forEach((symbol) => {
+                            if (!(symbol in nested_symbols_map))
+                                nested_symbols_map[symbol] = symbol_map[symbol];
+                        });
+
+                        that.calculate_volume_graph(
+                            node.data.graph,
+                            nested_symbols_map,
+                            volume_values
+                        );
+                    }
+                });
+            }
+        });
+    }
+
+    recalculate_volume_values(graph) {
+        this.badness_scale_center = 5;
+
+        let volume_values = [0];
+        this.calculate_volume_graph(
+            graph,
+            this.symbol_resolver.symbol_value_map,
+            volume_values
+        );
+
+        switch (this.badness_scale_method) {
+            case 'mean':
+                this.badness_scale_center = math.mean(volume_values);
+                break;
+            case 'mode':
+                this.badness_scale_center = math.mode(volume_values);
+                break;
+            case 'median':
+            default:
+                this.badness_scale_center = math.median(volume_values);
+                break;
+        }
+    }
+
+    refresh() {
+        this.clear_cached_volume_values();
+        this.recalculate_volume_values(this.renderer.graph);
+
+        this.renderer.draw_async();
+    }
+
+    shade_edge(edge, ctx) {
+        let volume = edge.data.volume;
+        if (volume !== undefined) {
+            // Only draw positive volumes.
+            if (volume <= 0)
+                return;
+
+            let badness = (1 / (this.badness_scale_center * 2)) * volume;
+            if (badness < 0)
+                badness = 0;
+            if (badness > 1)
+                badness = 1;
+            let color = getTempColor(badness);
+
+            edge.shade(this.renderer, ctx, color);
+        }
+    }
+
+    recursively_shade_sdfg(graph, ctx, ppp, visible_rect) {
+        graph.nodes().forEach(v => {
+            let state = graph.node(v);
+
+            // If we're zoomed out enough that the contents aren't visible, we
+            // skip the state.
+            if (ctx.lod && (ppp >= STATE_LOD || state.width / ppp < STATE_LOD))
+                return;
+
+            // If the node's invisible, we skip it.
+            if (ctx.lod && !state.intersect(visible_rect.x, visible_rect.y,
+                visible_rect.w, visible_rect.h))
+                return;
+
+            let state_graph = state.data.graph;
+            if (state_graph && !state.data.state.attributes.is_collapsed) {
+                state_graph.nodes().forEach(v => {
+                    let node = state_graph.node(v);
+
+                    // Skip the node if it's not visible.
+                    if (ctx.lod && !node.intersect(visible_rect.x,
+                        visible_rect.y, visible_rect.w, visible_rect.h))
+                        return;
+
+                    // If we're zoomed out enough that the node's contents
+                    // aren't visible or the node is collapsed, we skip it.
+                    if (node.data.node.attributes.is_collapsed ||
+                        (ctx.lod && ppp >= NODE_LOD))
+                        return;
+
+                    if (node instanceof NestedSDFG)
+                        this.recursively_shade_sdfg(
+                            node.data.graph, ctx, ppp, visible_rect
+                        );
+                });
+
+                state_graph.edges().forEach(e => {
+                    let edge = state_graph.edge(e);
+
+                    if (ctx.lod && !edge.intersect(visible_rect.x,
+                        visible_rect.y, visible_rect.w, visible_rect.h))
+                        return;
+
+                    this.shade_edge(edge, ctx);
+                });
+            }
+        });
     }
 
     draw() {
-        this.renderer.for_all_elements(0, 0, 0, 0,
-            (type, element, object, intersect) => {
-                if (object instanceof Edge) {
-                    let ctx = this.renderer.ctx;
-                    let edge = object;
-
-                    // Don't draw if we're zoomed out too far.
-                    let ppp = this.renderer.canvas_manager.points_per_pixel();
-                    if (ctx.lod && ppp >= EDGE_LOD)
-                        return;
-
-                    // Don't draw if the edge is outside the visible area.
-                    let visible_rect = this.renderer.visible_rect;
-                    if (!edge.intersect(visible_rect.x, visible_rect.y,
-                        visible_rect.w, visible_rect.h))
-                        return;
-
-                    let volume = edge.attributes().volume;
-                    if (volume !== undefined)
-                        volume = this.symbol_resolver.parse_symbol_expression(
-                            volume
-                        );
-
-                    if (volume) {
-                        // Update the highest obeserved volume if applicable.
-                        if (volume > this.highest_observed_volume)
-                            this.highest_observed_volume = volume;
-
-                        // Use either the default cutoff high volume, or the
-                        // maximum observed volume to indicate the badness of
-                        // this edge.
-                        let badness = (1 / Math.max(
-                            this.cutoff_high_volume,
-                            this.highest_observed_volume
-                        )) * volume;
-                        let color = getTempColor(badness);
-
-                        edge.shade(this.renderer, ctx, color);
-                    }
-                }
-            }
+        this.recursively_shade_sdfg(
+            this.renderer.graph,
+            this.renderer.ctx,
+            this.renderer.canvas_manager.points_per_pixel(),
+            this.renderer.visible_rect
         );
     }
 
     on_mouse_event(type, ev, mousepos, elements, foreground_elem, ends_drag) {
-        if ((type === 'click' && !ends_drag) || type === 'dblclick') {
-            if (foreground_elem && foreground_elem.data &&
-                foreground_elem.data.attributes &&
-                foreground_elem.data.attributes.volume) {
-                this.symbol_resolver.parse_symbol_expression(
-                    foreground_elem.data.attributes.volume, true
-                );
+        if (type === 'click' && !ends_drag) {
+            if (foreground_elem !== undefined &&
+                foreground_elem instanceof Edge) {
+                if (foreground_elem.data.volume === undefined) {
+                    if (foreground_elem.data.attributes.volume) {
+                        let that = this;
+                        this.symbol_resolver.parse_symbol_expression(
+                            foreground_elem.data.attributes.volume,
+                            that.symbol_resolver.symbol_value_map,
+                            true,
+                            () => {
+                                that.clear_cached_volume_values();
+                                that.recalculate_volume_values(
+                                    that.renderer.graph
+                                );
+                            }
+                        );
+                    }
+                }
             }
         }
         return false;
@@ -527,7 +753,7 @@ class OverlayManager {
 
         this.overlays = [];
 
-        this.symbol_resolver = new SymbolResolver();
+        this.symbol_resolver = new SymbolResolver(this.renderer);
     }
 
     register_overlay(type) {
@@ -564,6 +790,20 @@ class OverlayManager {
             default:
                 break;
         }
+    }
+
+    symbol_value_changed(symbol, value) {
+        this.symbol_resolver.symbol_value_changed(symbol, value);
+        this.overlays.forEach(overlay => {
+            overlay.refresh();
+        });
+    }
+
+    update_badness_scale_method(method) {
+        this.overlays.forEach(overlay => {
+            overlay.badness_scale_method = method;
+            overlay.refresh();
+        });
     }
 
     draw() {

--- a/renderer.js
+++ b/renderer.js
@@ -1412,6 +1412,9 @@ class SDFGRenderer {
 
         this.all_memlet_trees = memlet_tree_complete(this.graph);
 
+        // Make sure all visible overlays get recalculated if there are any.
+        this.overlay_manager.refresh();
+
         return this.graph;
     }
 

--- a/renderer.js
+++ b/renderer.js
@@ -1296,7 +1296,7 @@ class SDFGRenderer {
                 exit_preview_btn.className = 'button hidden';
                 if (vscode)
                     vscode.postMessage({
-                        type: 'getCurrentSdfg',
+                        type: 'sdfv.get_current_sdfg',
                     });
             };
             exit_preview_btn.title = 'Exit preview';
@@ -2305,7 +2305,7 @@ class SDFGRenderer {
                     }
 
                     vscode.postMessage({
-                        type: 'sortTransformations',
+                        type: 'sdfv.sort_transformations',
                         visibleElements: JSON.stringify(this.visible_elements()),
                         selectedElements: JSON.stringify(
                             clean_selected(this.selected_elements)

--- a/renderer.js
+++ b/renderer.js
@@ -1187,21 +1187,26 @@ class SDFGRenderer {
                                 that.draw_async();
                             }
                         );
-                        overlays_cmenu.addCheckableOption(
-                            'Static FLOPS analysis',
-                            that.overlay_manager.static_flops_overlay_active,
-                            (x, checked) => {
-                                if (checked)
-                                    that.overlay_manager.register_overlay(
-                                        GenericSdfgOverlay.OVERLAY_TYPE.STATIC_FLOPS
-                                    );
-                                else
-                                    that.overlay_manager.deregister_overlay(
-                                        GenericSdfgOverlay.OVERLAY_TYPE.STATIC_FLOPS
-                                    );
-                                that.draw_async();
-                            }
-                        );
+                        if (vscode) {
+                            // This is only possible in the context of the
+                            // VSCode extension, since it requires interaction
+                            // with the backend (at this point).
+                            overlays_cmenu.addCheckableOption(
+                                'Static FLOPS analysis',
+                                that.overlay_manager.static_flops_overlay_active,
+                                (x, checked) => {
+                                    if (checked)
+                                        that.overlay_manager.register_overlay(
+                                            GenericSdfgOverlay.OVERLAY_TYPE.STATIC_FLOPS
+                                        );
+                                    else
+                                        that.overlay_manager.deregister_overlay(
+                                            GenericSdfgOverlay.OVERLAY_TYPE.STATIC_FLOPS
+                                        );
+                                    that.draw_async();
+                                }
+                            );
+                        }
                         that.overlays_menu = overlays_cmenu;
                         that.overlays_menu.show(rect.left, rect.top);
                     }


### PR DESCRIPTION
- Addresses the following bugs:
  - [x] FLOPS overlay stops being drawn when nodes are collapsed and reopened
  - [x] Edge shading still gets drawn in some circumstances where the edge itself isn't visible anymore
  - [x] Subgraphs' symbol mapping is ignored
  - [x] Symbol definition popup causes the renderer to crash in some circumstances
  - [x] Symbol definition popup doesn't show for nodes when it should
  - [x] Symbol definition popup appears even if the symbols were all defined