### PR TITLE
Refactors and various smaller fixes in the context of VSCode

### DIFF
--- a/overlay_manager.js
+++ b/overlay_manager.js
@@ -549,8 +549,11 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
 
     calculate_volume_edge(edge, symbol_map, volume_values) {
         let volume_string = undefined;
-        if (edge.data && edge.data.attributes)
+        if (edge.data && edge.data.attributes) {
             volume_string = edge.data.attributes.volume;
+            if (volume_string !== undefined)
+                volume_string = volume_string.replace('**', '^');
+        }
         let volume = undefined;
         if (volume_string !== undefined)
             volume = this.symbol_resolver.parse_symbol_expression(
@@ -561,7 +564,7 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
         edge.data.volume = volume;
 
         if (volume !== undefined && volume > 0)
-                volume_values.push(volume);
+            volume_values.push(volume);
 
         return volume;
     }
@@ -798,6 +801,17 @@ class OverlayManager {
             default:
                 break;
         }
+    }
+
+    get_overlay(type) {
+        let overlay = undefined;
+        this.overlays.forEach(ol => {
+            if (ol.type === type) {
+                overlay = ol;
+                return;
+            }
+        });
+        return overlay;
     }
 
     symbol_value_changed(symbol, value) {

--- a/overlay_manager.js
+++ b/overlay_manager.js
@@ -8,8 +8,15 @@ class SymbolResolver {
 
         // Initialize the symbol mapping to the graph's symbol table.
         this.symbol_value_map = {};
-        Object.keys(this.sdfg.attributes.symbols).forEach((symbol) => {
-            this.symbol_value_map[symbol] = undefined;
+        Object.keys(this.sdfg.attributes.symbols).forEach((s) => {
+            if (this.sdfg.attributes.constants_prop !== undefined &&
+                Object.keys(this.sdfg.attributes.constants_prop).includes(s) &&
+                this.sdfg.attributes.constants_prop[s][0]['type'] === 'Scalar')
+                this.symbol_value_map[s] = this.sdfg.attributes.constants_prop[
+                    s
+                ][1];
+            else
+                this.symbol_value_map[s] = undefined;
         });
         this.symbols_to_define = [];
 

--- a/overlay_manager.js
+++ b/overlay_manager.js
@@ -65,7 +65,7 @@ class SymbolResolver {
                 () => {
                     if (vscode)
                         vscode.postMessage({
-                            type: 'symbol_resolver.define_symbol',
+                            type: 'analysis.define_symbol',
                             symbol: symbol,
                             definition: mapping[symbol],
                         });

--- a/overlay_manager.js
+++ b/overlay_manager.js
@@ -198,7 +198,6 @@ class GenericSdfgOverlay {
         this.renderer = renderer;
         this.type = type;
 
-        this.badness_scale_method = 'median';
         this.badness_scale_center = 5;
     }
 
@@ -362,7 +361,7 @@ class StaticFlopsOverlay extends GenericSdfgOverlay {
             flops_values
         );
 
-        switch (this.badness_scale_method) {
+        switch (this.overlay_manager.badness_scale_method) {
             case 'mean':
                 this.badness_scale_center = math.mean(flops_values);
                 break;
@@ -626,7 +625,7 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
             volume_values
         );
 
-        switch (this.badness_scale_method) {
+        switch (this.overlay_manager.badness_scale_method) {
             case 'mean':
                 this.badness_scale_center = math.mean(volume_values);
                 break;
@@ -761,6 +760,7 @@ class OverlayManager {
 
         this.memory_volume_overlay_active = false;
         this.static_flops_overlay_active = false;
+        this.badness_scale_method = 'median';
 
         this.overlays = [];
 
@@ -784,6 +784,7 @@ class OverlayManager {
             default:
                 break;
         }
+        this.renderer.draw_async();
     }
 
     deregister_overlay(type) {
@@ -801,6 +802,7 @@ class OverlayManager {
             default:
                 break;
         }
+        this.renderer.draw_async();
     }
 
     get_overlay(type) {
@@ -822,8 +824,8 @@ class OverlayManager {
     }
 
     update_badness_scale_method(method) {
+        this.badness_scale_method = method;
         this.overlays.forEach(overlay => {
-            overlay.badness_scale_method = method;
             overlay.refresh();
         });
     }

--- a/renderer.js
+++ b/renderer.js
@@ -1495,6 +1495,10 @@ class SDFGRenderer {
         // Make sure all visible overlays get recalculated if there are any.
         this.overlay_manager.refresh();
 
+        // If we're in a VSCode context, we also want to refresh the outline.
+        if (vscode)
+            outline(this, this.graph);
+
         return this.graph;
     }
 

--- a/renderer.js
+++ b/renderer.js
@@ -1968,16 +1968,14 @@ class SDFGRenderer {
                         y_end: this.mousepos.y,
                     };
 
-                    // Mark for redraw and resort
+                    // Mark for redraw
                     dirty = true;
-                    element_focus_changed = true;
                 } else {
                     this.canvas_manager.translate(event.movementX,
                         event.movementY);
 
-                    // Mark for redraw and resort
+                    // Mark for redraw
                     dirty = true;
-                    element_focus_changed = true;
                 }
             } else if (this.drag_start && event.buttons & 4) {
                 // Pan the view with the middle mouse button
@@ -2176,6 +2174,8 @@ class SDFGRenderer {
                 this.dragging = false;
                 ends_drag = true;
 
+                element_focus_changed = true;
+
                 if (this.box_select_rect) {
                     let elements_in_selection = [];
                     let start_x = Math.min(this.box_select_rect.x_start,
@@ -2279,39 +2279,8 @@ class SDFGRenderer {
             // If a listener in VSCode is present, update it about the new
             // viewport and tell it to re-sort the shown transformations.
             try {
-                if (vscode) {
-                    function clean_selected(selected_elements) {
-                        let elems = [];
-                        selected_elements.forEach((el) => {
-                            let parent_id =
-                                el.parent_id === null ? -1 : el.parent_id;
-                            let type = 'other';
-                            if (el.data.node)
-                                type = 'node';
-                            else if (el.data.state)
-                                type = 'state';
-                            else if (el.data.type === 'InterstateEdge')
-                                type = 'isedge';
-                            else if (el.data.type === 'Memlet')
-                                type = 'edge';
-                            elems.push({
-                                type: type,
-                                sdfg_id: el.sdfg.sdfg_list_id,
-                                state_id: parent_id,
-                                id: el.id,
-                            });
-                        });
-                        return elems;
-                    }
-
-                    vscode.postMessage({
-                        type: 'sdfv.sort_transformations',
-                        visibleElements: JSON.stringify(this.visible_elements()),
-                        selectedElements: JSON.stringify(
-                            clean_selected(this.selected_elements)
-                        ),
-                    });
-                }
+                if (vscode)
+                    sort_transformations(refresh_transformation_list);
             } catch (ex) {
                 // Do nothing
             }

--- a/renderer.js
+++ b/renderer.js
@@ -1242,54 +1242,37 @@ class SDFGRenderer {
                     cmenu.addOption("Save all as PDF", x => that.save_as_pdf(true));
                 }
                 cmenu.addCheckableOption("Inclusive ranges", that.inclusive_ranges, (x, checked) => { that.inclusive_ranges = checked; });
-                cmenu.addOption(
-                    'Overlays',
-                    () => {
-                        if (that.overlays_menu && that.overlays_menu.visible()) {
-                            that.overlays_menu.destroy();
-                            return;
-                        }
-                        let rect = cmenu._cmenu_elem.getBoundingClientRect();
-                        let overlays_cmenu = new ContextMenu();
-                        overlays_cmenu.addCheckableOption(
-                            'Memory volume analysis',
-                            that.overlay_manager.memory_volume_overlay_active,
-                            (x, checked) => {
-                                if (checked)
-                                    that.overlay_manager.register_overlay(
-                                        GenericSdfgOverlay.OVERLAY_TYPE.MEMORY_VOLUME
-                                    );
-                                else
-                                    that.overlay_manager.deregister_overlay(
-                                        GenericSdfgOverlay.OVERLAY_TYPE.MEMORY_VOLUME
-                                    );
-                                that.draw_async();
+                if (!vscode)
+                    cmenu.addOption(
+                        'Overlays',
+                        () => {
+                            if (that.overlays_menu && that.overlays_menu.visible()) {
+                                that.overlays_menu.destroy();
+                                return;
                             }
-                        );
-                        if (vscode) {
-                            // This is only possible in the context of the
-                            // VSCode extension, since it requires interaction
-                            // with the backend (at this point).
+                            let rect = cmenu._cmenu_elem.getBoundingClientRect();
+                            let overlays_cmenu = new ContextMenu();
                             overlays_cmenu.addCheckableOption(
-                                'Static FLOPS analysis',
-                                that.overlay_manager.static_flops_overlay_active,
+                                'Memory volume analysis',
+                                that.overlay_manager.memory_volume_overlay_active,
                                 (x, checked) => {
                                     if (checked)
                                         that.overlay_manager.register_overlay(
-                                            GenericSdfgOverlay.OVERLAY_TYPE.STATIC_FLOPS
+                                            GenericSdfgOverlay.OVERLAY_TYPE.MEMORY_VOLUME
                                         );
                                     else
                                         that.overlay_manager.deregister_overlay(
-                                            GenericSdfgOverlay.OVERLAY_TYPE.STATIC_FLOPS
+                                            GenericSdfgOverlay.OVERLAY_TYPE.MEMORY_VOLUME
                                         );
                                     that.draw_async();
+                                    if (vscode)
+                                        refresh_analysis_pane();
                                 }
                             );
+                            that.overlays_menu = overlays_cmenu;
+                            that.overlays_menu.show(rect.left, rect.top);
                         }
-                        that.overlays_menu = overlays_cmenu;
-                        that.overlays_menu.show(rect.left, rect.top);
-                    }
-                );
+                    );
                 cmenu.addCheckableOption("Hide Access Nodes", that.omit_access_nodes, (x, checked) => { that.omit_access_nodes = checked; that.relayout()});
                 that.menu = cmenu;
                 that.menu.show(rect.left, rect.bottom);

--- a/renderer.js
+++ b/renderer.js
@@ -1357,10 +1357,17 @@ class SDFGRenderer {
             exit_preview_btn.style = 'padding-bottom: 0px; user-select: none';
             exit_preview_btn.onclick = () => {
                 exit_preview_btn.className = 'button hidden';
-                if (vscode)
+                window.viewing_history_state = false;
+                if (vscode) {
                     vscode.postMessage({
                         type: 'sdfv.get_current_sdfg',
+                        prevent_refreshes: true,
                     });
+                    vscode.postMessage({
+                        type: 'transformation_history.refresh',
+                        reset_active: true,
+                    });
+                }
             };
             exit_preview_btn.title = 'Exit preview';
             this.toolbar.appendChild(exit_preview_btn);


### PR DESCRIPTION
- Minimize the number of times the transformation list gets resorted when interacting with the graph
    - Only perform resorting when the element focus changed, or when a movement action finishes (mouse is released, viewport is zoomed)
- Refactor some VSCode post-message commands with regards to a message passing API change in the extension
- Make the overlay manager keep track of the badness scale method instead of each overlay individually
- Remove the overlay menu if within the VSCode context - it is handled separately there
- Remove the FLOPS analysis overlay from the overlay menu. This is only available in VSCode and thus only shown there
- Initialize symbol values of pre-defined symbol values via the `constants_prop` property