### PR TITLE
Hidden access node fixes

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1242,7 +1242,7 @@ class SDFGRenderer {
                     cmenu.addOption("Save all as PDF", x => that.save_as_pdf(true));
                 }
                 cmenu.addCheckableOption("Inclusive ranges", that.inclusive_ranges, (x, checked) => { that.inclusive_ranges = checked; });
-                if (!vscode)
+                if (!in_vscode)
                     cmenu.addOption(
                         'Overlays',
                         () => {
@@ -1265,7 +1265,7 @@ class SDFGRenderer {
                                             GenericSdfgOverlay.OVERLAY_TYPE.MEMORY_VOLUME
                                         );
                                     that.draw_async();
-                                    if (vscode)
+                                    if (in_vscode)
                                         refresh_analysis_pane();
                                 }
                             );
@@ -1486,8 +1486,10 @@ class SDFGRenderer {
         this.overlay_manager.refresh();
 
         // If we're in a VSCode context, we also want to refresh the outline.
-        if (vscode)
-            outline(this, this.graph);
+        try {
+            if (vscode)
+                outline(this, this.graph);
+        } catch (ex) { }
 
         return this.graph;
     }

--- a/sdfg_utils.js
+++ b/sdfg_utils.js
@@ -143,17 +143,13 @@ function find_exit_for_entry(nodes, entry_node) {
 }
 
 
-function check_and_redirect_edge(edge, drawn_nodes, sdfg_state, omit_access_nodes = true) {
+function check_and_redirect_edge(edge, drawn_nodes, sdfg_state) {
     // If destination is not drawn, no need to draw the edge
     if (!drawn_nodes.has(edge.dst))
         return null;
     // If both source and destination are in the graph, draw edge as-is
-    if (drawn_nodes.has(edge.src)) {
-        // If access nodes are not hidden and it's a shortcut edge, then don't draw the edge
-        if (!omit_access_nodes && edge.shortcut)
-            return null;
+    if (drawn_nodes.has(edge.src))
         return edge;
-    }
 
     // If immediate scope parent node is in the graph, redirect
     let scope_src = sdfg_state.nodes[edge.src].scope_entry;

--- a/sdfv.js
+++ b/sdfv.js
@@ -174,6 +174,18 @@ function find_in_graph(renderer, sdfg, query, case_sensitive=false) {
         d.className = 'context_menu_option';
         d.innerHTML = result.type() + ' ' + result.label();
         d.onclick = () => {renderer.zoom_to_view([result])};
+        d.onmouseenter = () => {
+            if (!result.highlighted) {
+                result.highlighted = true;
+                renderer.draw_async();
+            }
+        };
+        d.onmouseleave = () => {
+            if (result.highlighted) {
+                result.highlighted = false;
+                renderer.draw_async();
+            }
+        };
         sidebar.appendChild(d);
     }
 


### PR DESCRIPTION
Contains improvements to the hidden access nodes mode:

- Memlet trees are shown correctly
- Maps and nested SDFGs are connected correctly, also when collapsing/uncollapsing states, maps or nested SDFGs

Fixes vscode detection outside of vscode

Highlights the nodes when hovering over the search results