### PR TITLE
Improve speed for loading large instrumentation reports, add count to runtime overlay's tooltip

### DIFF
--- a/overlay_manager.js
+++ b/overlay_manager.js
@@ -351,7 +351,8 @@ class RuntimeMicroSecondsOverlay extends GenericSdfgOverlay {
                         'Min: ' + this.pretty_print_micros(rt_summary['min']) +
                         '\nMax: ' + this.pretty_print_micros(rt_summary['max']) +
                         '\nMean: ' + this.pretty_print_micros(rt_summary['mean']) +
-                        '\nMedian: ' + this.pretty_print_micros(rt_summary['med'])
+                        '\nMedian: ' + this.pretty_print_micros(rt_summary['med']) +
+                        '\nCount: ' + rt_summary['count']
                     );
                 };
         }

--- a/overlay_manager.js
+++ b/overlay_manager.js
@@ -755,8 +755,10 @@ class MemoryVolumeOverlay extends GenericSdfgOverlay {
         let volume_string = undefined;
         if (edge.data && edge.data.attributes) {
             volume_string = edge.data.attributes.volume;
-            if (volume_string !== undefined)
-                volume_string = volume_string.replace('**', '^');
+            if (volume_string !== undefined) {
+                volume_string = volume_string.replace(/\*\*/g, '^');
+                volume_string = volume_string.replace(/ceiling/g, 'ceil');
+            }
         }
         let volume = undefined;
         if (volume_string !== undefined)

--- a/sdfv.js
+++ b/sdfv.js
@@ -72,6 +72,23 @@ function load_instrumentation_report_callback() {
     instrumentation_report_read_complete(JSON.parse(fr.result));
 }
 
+/**
+ * Get the min/max values of an array.
+ * This is more stable than Math.min/max for large arrays, since Math.min/max
+ * is recursive and causes a too high stack-length with long arrays.
+ */
+function get_minmax(arr) {
+    var max = -Number.MAX_VALUE;
+    var min = Number.MAX_VALUE;
+    arr.forEach(val => {
+        if (val > max)
+            max = val;
+        if (val < min)
+            min = val;
+    });
+    return [min, max];
+}
+
 function instrumentation_report_read_complete(report) {
     let runtime_map = {};
 
@@ -98,11 +115,15 @@ function instrumentation_report_read_complete(report) {
 
         for (const key in runtime_map) {
             const values = runtime_map[key];
+            const minmax = get_minmax(values);
+            const min = minmax[0];
+            const max = minmax[1];
             const runtime_summary = {
-                'min': math.min(...values),
-                'max': math.max(...values),
+                'min': min,
+                'max': max,
                 'mean': math.mean(values),
                 'med': math.median(values),
+                'count': values.length,
             };
             runtime_map[key] = runtime_summary;
         }


### PR DESCRIPTION
- Allow for the loading of larger instrumentation reports by removing a math.js recursive min/max finding.
- Add `count` to the instrumentation report overlay.
- Fix invalid parsing of volume strings in static memory overlay.