### PR TITLE
Fix memlet trees not highlighting if a renderer's SDFG is changed

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -1611,6 +1611,7 @@ class SDFGRenderer {
 
     set_sdfg(new_sdfg) {
         this.sdfg = new_sdfg;
+        this.all_memlet_trees_sdfg = memlet_tree_complete(this.sdfg);
         this.relayout();
         this.draw_async();
     }


### PR DESCRIPTION
If the renderer's SDFG is changed via `set_sdfg`, memlet trees need to be correctly recomputed to update the fast lookup.