### PR TITLE
Add a missing node dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@spcl/sdfv",
-    "version": "1.0.28",
+    "version": "1.0.29",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@spcl/sdfv",
-            "version": "1.0.28",
+            "version": "1.0.29",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@babel/runtime": "^7.17.2",
@@ -18,7 +18,8 @@
                 "jquery": "^3.6.0",
                 "mathjs": "^10.0.0",
                 "process": "^0.11.10",
-                "stream-browserify": "^3.0.0"
+                "stream-browserify": "^3.0.0",
+                "zlib": "^1.0.5"
             },
             "devDependencies": {
                 "@babel/cli": "^7.17.3",
@@ -3146,9 +3147,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.20.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.4.tgz",
-            "integrity": "sha512-ok1d+1WpnU24XYN7oC3QWgTyMhY/avPJ/r9T00xxvUOIparA/gc+UPUMaod3i+G6s+nI2nUb9xZ5k794uIwShw==",
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.0.tgz",
+            "integrity": "sha512-UQxE0DIhRB5z/zDz9iA03BOfxaN2+GQdBYH/2WrSIWEUrnpzTPJbhqt+umq6r3acaPRTW1FNTkrcp0PXgtFkvA==",
             "dev": true,
             "funding": [
                 {
@@ -3161,11 +3162,10 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001349",
-                "electron-to-chromium": "^1.4.147",
-                "escalade": "^3.1.1",
+                "caniuse-lite": "^1.0.30001358",
+                "electron-to-chromium": "^1.4.164",
                 "node-releases": "^2.0.5",
-                "picocolors": "^1.0.0"
+                "update-browserslist-db": "^1.0.0"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -3234,9 +3234,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001356",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001356.tgz",
-            "integrity": "sha512-/30854bktMLhxtjieIxsrJBfs2gTM1pel6MXKF3K+RdIVJZcsn2A2QdhsuR4/p9+R204fZw0zCBBhktX8xWuyQ==",
+            "version": "1.0.30001358",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
+            "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==",
             "dev": true,
             "funding": [
                 {
@@ -3495,9 +3495,9 @@
             "hasInstallScript": true
         },
         "node_modules/core-js-compat": {
-            "version": "3.23.1",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.23.1.tgz",
-            "integrity": "sha512-KeYrEc8t6FJsKYB2qnDwRHWaC0cJNaqlHfCpMe5q3j/W1nje3moib/txNklddLPCtGb+etcBIyJ8zuMa/LN5/A==",
+            "version": "3.23.2",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.23.2.tgz",
+            "integrity": "sha512-lrgZvxFwbQp9v7E8mX0rJ+JX7Bvh4eGULZXA1IAyjlsnWvCdw6TF8Tg6xtaSUSJMrSrMaLdpmk+V54LM1dvfOA==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.20.4",
@@ -3684,9 +3684,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.161",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.161.tgz",
-            "integrity": "sha512-sTjBRhqh6wFodzZtc5Iu8/R95OkwaPNn7tj/TaDU5nu/5EFiQDtADGAXdR4tJcTEHlYfJpHqigzJqHvPgehP8A==",
+            "version": "1.4.165",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.165.tgz",
+            "integrity": "sha512-DKQW1lqUSAYQvn9dnpK7mWaDpWbNOXQLXhfCi7Iwx0BKxdZOxkKcCyKw1l3ihWWW5iWSxKKbhEUoNRoHvl/hbA==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -7576,6 +7576,32 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/update-browserslist-db": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.3.tgz",
+            "integrity": "sha512-ufSazemeh9Gty0qiWtoRpJ9F5Q5W3xdIPm1UZQqYQv/q0Nyb9EMHUB2lu+O9x1re9WsorpMAUu4Y6Lxcs5n+XQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/browserslist"
+                },
+                {
+                    "type": "tidelift",
+                    "url": "https://tidelift.com/funding/github/npm/browserslist"
+                }
+            ],
+            "dependencies": {
+                "escalade": "^3.1.1",
+                "picocolors": "^1.0.0"
+            },
+            "bin": {
+                "browserslist-lint": "cli.js"
+            },
+            "peerDependencies": {
+                "browserslist": ">= 4.21.0"
+            }
+        },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8121,6 +8147,15 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
+        },
+        "node_modules/zlib": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
+            "integrity": "sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w==",
+            "hasInstallScript": true,
+            "engines": {
+                "node": ">=0.2.0"
+            }
         }
     },
     "dependencies": {
@@ -10460,16 +10495,15 @@
             }
         },
         "browserslist": {
-            "version": "4.20.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.4.tgz",
-            "integrity": "sha512-ok1d+1WpnU24XYN7oC3QWgTyMhY/avPJ/r9T00xxvUOIparA/gc+UPUMaod3i+G6s+nI2nUb9xZ5k794uIwShw==",
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.0.tgz",
+            "integrity": "sha512-UQxE0DIhRB5z/zDz9iA03BOfxaN2+GQdBYH/2WrSIWEUrnpzTPJbhqt+umq6r3acaPRTW1FNTkrcp0PXgtFkvA==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001349",
-                "electron-to-chromium": "^1.4.147",
-                "escalade": "^3.1.1",
+                "caniuse-lite": "^1.0.30001358",
+                "electron-to-chromium": "^1.4.164",
                 "node-releases": "^2.0.5",
-                "picocolors": "^1.0.0"
+                "update-browserslist-db": "^1.0.0"
             }
         },
         "buffer": {
@@ -10509,9 +10543,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001356",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001356.tgz",
-            "integrity": "sha512-/30854bktMLhxtjieIxsrJBfs2gTM1pel6MXKF3K+RdIVJZcsn2A2QdhsuR4/p9+R204fZw0zCBBhktX8xWuyQ==",
+            "version": "1.0.30001358",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001358.tgz",
+            "integrity": "sha512-hvp8PSRymk85R20bsDra7ZTCpSVGN/PAz9pSAjPSjKC+rNmnUk5vCRgJwiTT/O4feQ/yu/drvZYpKxxhbFuChw==",
             "dev": true
         },
         "chalk": {
@@ -10700,9 +10734,9 @@
             "dev": true
         },
         "core-js-compat": {
-            "version": "3.23.1",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.23.1.tgz",
-            "integrity": "sha512-KeYrEc8t6FJsKYB2qnDwRHWaC0cJNaqlHfCpMe5q3j/W1nje3moib/txNklddLPCtGb+etcBIyJ8zuMa/LN5/A==",
+            "version": "3.23.2",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.23.2.tgz",
+            "integrity": "sha512-lrgZvxFwbQp9v7E8mX0rJ+JX7Bvh4eGULZXA1IAyjlsnWvCdw6TF8Tg6xtaSUSJMrSrMaLdpmk+V54LM1dvfOA==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.20.4",
@@ -10845,9 +10879,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.4.161",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.161.tgz",
-            "integrity": "sha512-sTjBRhqh6wFodzZtc5Iu8/R95OkwaPNn7tj/TaDU5nu/5EFiQDtADGAXdR4tJcTEHlYfJpHqigzJqHvPgehP8A==",
+            "version": "1.4.165",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.165.tgz",
+            "integrity": "sha512-DKQW1lqUSAYQvn9dnpK7mWaDpWbNOXQLXhfCi7Iwx0BKxdZOxkKcCyKw1l3ihWWW5iWSxKKbhEUoNRoHvl/hbA==",
             "dev": true
         },
         "emoji-regex": {
@@ -13707,6 +13741,16 @@
             "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
             "dev": true
         },
+        "update-browserslist-db": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.3.tgz",
+            "integrity": "sha512-ufSazemeh9Gty0qiWtoRpJ9F5Q5W3xdIPm1UZQqYQv/q0Nyb9EMHUB2lu+O9x1re9WsorpMAUu4Y6Lxcs5n+XQ==",
+            "dev": true,
+            "requires": {
+                "escalade": "^3.1.1",
+                "picocolors": "^1.0.0"
+            }
+        },
         "uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -14092,6 +14136,11 @@
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
             "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
             "dev": true
+        },
+        "zlib": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/zlib/-/zlib-1.0.5.tgz",
+            "integrity": "sha512-40fpE2II+Cd3k8HWTWONfeKE2jL+P42iWJ1zzps5W51qcTsOUKM5Q5m2PFb0CLxlmFAaUuUdJGc3OfZy947v0w=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spcl/sdfv",
-    "version": "1.0.28",
+    "version": "1.0.29",
     "description": "A standalone viewer for SDFGs",
     "homepage": "https://github.com/spcl/dace-webclient",
     "main": "out/index.js",
@@ -58,6 +58,7 @@
         "jquery": "^3.6.0",
         "mathjs": "^10.0.0",
         "process": "^0.11.10",
-        "stream-browserify": "^3.0.0"
+        "stream-browserify": "^3.0.0",
+        "zlib": "^1.0.5"
     }
 }


### PR DESCRIPTION
While `browserify-zlib` is required for the web-deployment via webpack, the node deployment (as an npm package, e.g., in VSCode) requires actual `zlib`.