### PR TITLE
October Improvements 1/2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@spcl/sdfv",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@spcl/sdfv",
-            "version": "1.1.0",
+            "version": "1.1.1",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -23,6 +23,7 @@
                 "material-icons": "^1.13.1",
                 "material-symbols": "^0.6.0",
                 "mathjs": "^11.5.0",
+                "monaco-editor": "^0.44.0",
                 "patch-package": "^6.5.1",
                 "pixi-viewport": "4.24",
                 "pixi.js": "6.1.3",
@@ -9744,6 +9745,11 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/monaco-editor": {
+            "version": "0.44.0",
+            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.44.0.tgz",
+            "integrity": "sha512-5SmjNStN6bSuSE5WPT2ZV+iYn1/yI9sd4Igtk23ChvqB7kDk9lZbB9F5frsuvpB+2njdIeGGFf2G4gbE6rCC9Q=="
         },
         "node_modules/ms": {
             "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
         "material-icons": "^1.13.1",
         "material-symbols": "^0.6.0",
         "mathjs": "^11.5.0",
+        "monaco-editor": "^0.44.0",
         "patch-package": "^6.5.1",
         "pixi-viewport": "4.24",
         "pixi.js": "6.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spcl/sdfv",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "A standalone viewer for SDFGs",
     "homepage": "https://github.com/spcl/dace-webclient",
     "main": "out/index.js",

--- a/sdfv.css
+++ b/sdfv.css
@@ -383,6 +383,12 @@ pre.code code {
   --color-selected-highlighted: darkorange;
   --color-minimap-viewport: #ff7a00;
 
+  --tasklet-input-color: black;
+  --tasklet-output-color: black;
+  --tasklet-symbol-color: red;
+  --tasklet-number-color: black;
+  --tasklet-highlighted-color: green;
+
   --overlay-color-lightness: 0.5;
   --overlay-color-saturation: 1.0;
 

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -935,11 +935,16 @@ export class Memlet extends Edge {
             renderer.set_tooltip((c) => this.tooltip(c, renderer));
         ctx.fillStyle = ctx.strokeStyle = this.strokeStyle(renderer);
 
-        // CR edges have dashed lines
-        if (this.data.attributes.wcr !== null)
-            ctx.setLineDash([2, 2]);
-        else
-            ctx.setLineDash([1, 0]);
+        if (this.attributes().data) {
+            // CR edges have dashed lines
+            if (this.data.attributes.wcr !== null)
+                ctx.setLineDash([3, 2]);
+            else
+                ctx.setLineDash([1, 0]);
+        } else {
+            // Empty memlet, i.e., a dependency edge. Show with dotted lines.
+            ctx.setLineDash([1, 2]);
+        }
 
         ctx.stroke();
 
@@ -2033,11 +2038,13 @@ function batchedDrawEdges(
         ))
             return;
 
-        // WCR Edge.
         if (!(graph instanceof State)) {
-            if (edge.parent_id !== null && edge.data.attributes.wcr !== null) {
-                deferredEdges.push(edge);
-                return;
+            if (edge.parent_id !== null) {
+                // WCR edge or dependency edge.
+                if (edge.attributes().wcr !== null || !edge.attributes().data) {
+                    deferredEdges.push(edge);
+                    return;
+                }
             }
         }
 

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -944,8 +944,7 @@ export class Memlet extends Edge {
             else
                 ctx.setLineDash([1, 0]);
         } else {
-            // Empty memlet, i.e., a dependency edge. Show with dotted lines.
-            ctx.setLineDash([1, 2]);
+            // Empty memlet, i.e., a dependency edge. Do not draw the arrowhead.
             skipArrow = true;
         }
 

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -936,6 +936,7 @@ export class Memlet extends Edge {
             renderer.set_tooltip((c) => this.tooltip(c, renderer));
         ctx.fillStyle = ctx.strokeStyle = this.strokeStyle(renderer);
 
+        let skipArrow = false;
         if (this.attributes().data) {
             // CR edges have dashed lines
             if (this.data.attributes.wcr !== null)
@@ -945,6 +946,7 @@ export class Memlet extends Edge {
         } else {
             // Empty memlet, i.e., a dependency edge. Show with dotted lines.
             ctx.setLineDash([1, 2]);
+            skipArrow = true;
         }
 
         ctx.stroke();
@@ -963,10 +965,11 @@ export class Memlet extends Edge {
                 );
         }
 
-        this.drawArrow(
-            ctx, this.points[this.points.length - 2],
-            this.points[this.points.length - 1], 3
-        );
+        if (!skipArrow)
+            this.drawArrow(
+                ctx, this.points[this.points.length - 2],
+                this.points[this.points.length - 1], 3
+            );
     }
 
     public tooltip(


### PR DESCRIPTION
- [x] Visualize empty memlets (i.e., dependency edges) as dotted lines. Closes https://github.com/spcl/dace-vscode/issues/245.
  The example below shows both an empty memlet (top), as well as the current style of WCR edges (bottom) and how they differ in the visualization.
  ![image](https://github.com/spcl/dace-webclient/assets/9193712/1a939be9-b072-4c87-88ca-29c0202c9c89)
- [x] Highlight symbols being used in tasklets. Additionally, hovering over a connector highlights the corresponding variables inside the tasklet code. The image below shows both a symbol being highlighted (red), and a connector (green). The colors are CSS customizable variables. Closes https://github.com/spcl/dace-vscode/issues/243.
  ![image](https://github.com/spcl/dace-webclient/assets/9193712/9343e4d4-26a7-44fe-b215-23cbece96944)