### PR TITLE
Make general control flow regions work

### DIFF
--- a/sdfv.css
+++ b/sdfv.css
@@ -369,6 +369,9 @@ pre.code code {
   --loop-background-color: #ffffff;
   --loop-background-simple-color: #e0e0e0;
   --loop-foreground-color: #000000;
+  --control-flow-region-background-color: #ffffff;
+  --control-flow-region-background-simple-color: #e0e0e0;
+  --control-flow-region-foreground-color: #000000;
   --interstate-edge-color: #86add9;
   --connector-scoped-color: #c1dfe690;
   --connector-unscoped-color: #f0fdff;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -3362,7 +3362,7 @@ function relayoutStateMachine(
                 blockInfo.width = Math.max(
                     maxLabelWidth, ctx.measureText(block.label).width
                 ) + 3 * LoopRegion.META_LABEL_MARGIN;
-            } else if (blockElem instanceof State) {
+            } else {
                 blockInfo.width = ctx.measureText(blockInfo.label).width;
             }
         } else {
@@ -3866,6 +3866,7 @@ function relayoutSDFGBlock(
 ): DagreSDFG | null {
     switch (block.type) {
         case SDFGElementType.LoopRegion:
+        case SDFGElementType.ControlFlowRegion:
             return relayoutStateMachine(
                 ctx, block as StateMachineType, sdfg, sdfgList, stateParentList,
                 omitAccessNodes, parent


### PR DESCRIPTION
This small iterative PR makes general purpose control flow regions work with the layout and rendering engines. Control flow regions that are not loops are rendered as state machines in simple (named) boxes that can be collapsed. Note that the design is temporary and will need to be iterated upon, both for control flow regions as well as for specialized regions like loops.

![image](https://github.com/spcl/dace-webclient/assets/9193712/99ee5bec-917e-47c4-8390-10c945577097)