### PR TITLE
Compatibility with new SDFG changes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -26,6 +26,7 @@ module.exports = {
                 "argsIgnorePattern": "^_",
             },
         ],
+        "@typescript-eslint/no-unsafe-declaration-merging": "warn",
         "@typescript-eslint/no-var-requires": "warn",
         "semi": "error",
         "no-useless-escape": "off",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spcl/sdfv",
-    "version": "1.1.5",
+    "version": "1.1.6",
     "description": "A standalone viewer for SDFGs",
     "homepage": "https://github.com/spcl/dace-webclient",
     "main": "out/index.js",

--- a/samples/example.sdfg
+++ b/samples/example.sdfg
@@ -584,7 +584,7 @@
     }
   ],
   "edges": [],
-  "sdfg_list_id": 0,
-  "start_state": 0,
+  "cfg_list_id": 0,
+  "start_block": 0,
   "dace_version": "0.13.3"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,8 +86,8 @@ export interface JsonSDFGState extends JsonSDFGBlock {
 
 export type JsonSDFG = {
     type: string,
-    start_state: number,
-    sdfg_list_id: number,
+    start_block: number,
+    cfg_list_id: number,
     attributes: any,
     edges: any[], // TODO
     nodes: any[], // TODO

--- a/src/overlays/memory_location_overlay.ts
+++ b/src/overlays/memory_location_overlay.ts
@@ -147,7 +147,7 @@ export class MemoryLocationOverlay extends GenericSdfgOverlay {
         if (node instanceof SDFGNode) {
             if (node.data?.node?.scope_entry !== undefined &&
                 node.parent_id !== null) {
-                scopeNode = node.sdfg.nodes[node.parent_id].nodes[
+                scopeNode = node.parentElem?.data.state.nodes[
                     node.data.node.scope_entry
                 ];
                 parentId = node.parent_id;

--- a/src/renderer/canvas_manager.ts
+++ b/src/renderer/canvas_manager.ts
@@ -7,7 +7,7 @@ import {
     getPositioningInfo,
     initialize_positioning_info,
 } from '../utils/sdfg/sdfg_utils';
-import { SDFGRenderer, SDFGListType } from './renderer';
+import { SDFGRenderer, CFGListType } from './renderer';
 import { DagreSDFG, intersectRect, Point2D } from '../index';
 
 const animation_duration = 1000;
@@ -322,7 +322,7 @@ export class CanvasManager {
      * @param {*} old_mousepos      Old mouse position in canvas coordinates
      * @param {*} new_mousepos      New mouse position in canvas coordinates
      * @param {*} entire_graph      Reference to the entire graph
-     * @param {*} sdfg_list         List of SDFGs and nested SDFGs
+     * @param {*} cfg_list          List of CFGs in this SDFG
      * @param {*} state_parent_list List of parent elements to SDFG states
      * @param {*} drag_start        Drag starting event, undefined if no drag
      * @param {*} update_position_info Whether to update positioning information
@@ -334,7 +334,7 @@ export class CanvasManager {
         old_mousepos: Point2D,
         new_mousepos: Point2D,
         entire_graph: DagreSDFG,
-        sdfg_list: SDFGListType,
+        cfg_list: CFGListType,
         state_parent_list: any[],
         drag_start: any,
         update_position_info: boolean = true,
@@ -348,7 +348,7 @@ export class CanvasManager {
         const in_edges: any[] = [];
 
         // Find the parent graph in the list of available SDFGs
-        let parent_graph = sdfg_list[el.sdfg.sdfg_list_id];
+        let parent_graph = cfg_list[el.sdfg.cfg_list_id];
         let parent_element: SDFGElement | null = null;
 
         if (
@@ -359,7 +359,7 @@ export class CanvasManager {
             // we're currently in a nested SDFG. If we're also moving a state,
             // this means that its parent element is found in the list of
             // parents to states (state_parent_list)
-            parent_element = state_parent_list[el.sdfg.sdfg_list_id];
+            parent_element = state_parent_list[el.sdfg.cfg_list_id];
         } else if (el.parent_id !== null && parent_graph) {
             // If the parent_id isn't null and there is a parent graph, we can
             // look up the parent node via the element's parent_id

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -18,6 +18,7 @@ import {
     Point2D,
     SDFVTooltipFunc,
     SimpleRect,
+    checkCompatSave,
     stringify_sdfg
 } from '../index';
 import { SMLayouter } from '../layouter/state_machine/sm_layouter';
@@ -1365,8 +1366,10 @@ export class SDFGRenderer extends EventEmitter {
 
     public save_sdfg(): void {
         const name = this.sdfg.attributes.name;
-        const contents = 'data:text/json;charset=utf-8,' +
-            encodeURIComponent(stringify_sdfg(this.sdfg));
+        const sdfgString = stringify_sdfg(checkCompatSave(this.sdfg));
+        const contents = 'data:text/json;charset=utf-8,' + encodeURIComponent(
+            sdfgString
+        );
         this.save(name + '.sdfg', contents);
     }
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -71,7 +71,7 @@ declare const vscode: any | null;
 
 type SDFGElementGroup = 'states' | 'nodes' | 'edges' | 'isedges';
 // If type is explicitly set, dagre typecheck fails with integer node ids
-export type SDFGListType = any[];//{ [key: number]: DagreSDFG };
+export type CFGListType = any[];//{ [key: number]: DagreSDFG };
 
 function check_valid_add_position(
     type: SDFGElementType | null,
@@ -127,7 +127,7 @@ export interface SDFGRenderer {
 
 export class SDFGRenderer extends EventEmitter {
 
-    protected sdfg_list: any = {};
+    protected cfg_list: any = {};
     protected graph: DagreSDFG | null = null;
     // Parent-pointing SDFG tree.
     protected sdfg_tree: { [key: number]: number } = {};
@@ -993,8 +993,8 @@ export class SDFGRenderer extends EventEmitter {
             (otype: SDFGElementGroup, odict: any, obj: any) => {
                 if (obj.type === SDFGElementType.NestedSDFG &&
                     obj.attributes.sdfg)
-                    this.sdfg_tree[obj.attributes.sdfg.sdfg_list_id] =
-                        odict.sdfg.sdfg_list_id;
+                    this.sdfg_tree[obj.attributes.sdfg.cfg_list_id] =
+                        odict.sdfg.cfg_list_id;
             }
         );
     }
@@ -1063,9 +1063,9 @@ export class SDFGRenderer extends EventEmitter {
         if (!this.ctx)
             throw new Error('No context found while performing layouting');
 
-        this.sdfg_list = {};
+        this.cfg_list = {};
         this.graph = relayoutStateMachine(
-            this.ctx, this.sdfg, this.sdfg, this.sdfg_list,
+            this.ctx, this.sdfg, this.sdfg, this.cfg_list,
             this.state_parent_list, !SDFVSettings.showAccessNodes, undefined
         );
         this.onresize();
@@ -1130,7 +1130,7 @@ export class SDFGRenderer extends EventEmitter {
                     this.canvas_manager?.translate_element(
                         node, { x: node.x, y: node.y },
                         { x: node.x + dx, y: node.y + dy }, this.graph,
-                        this.sdfg_list, this.state_parent_list, undefined, false
+                        this.cfg_list, this.state_parent_list, undefined, false
                     );
             }
 
@@ -1163,7 +1163,7 @@ export class SDFGRenderer extends EventEmitter {
                     if (this.graph)
                         this.canvas_manager?.translate_element(
                             edge, { x: 0, y: 0 },
-                            { x: 0, y: 0 }, this.graph, this.sdfg_list,
+                            { x: 0, y: 0 }, this.graph, this.cfg_list,
                             this.state_parent_list, undefined, false, false,
                             final_pos_d
                         );
@@ -1913,7 +1913,7 @@ export class SDFGRenderer extends EventEmitter {
                                     traverseRecursive(
                                         node.data.graph,
                                         node.attributes().sdfg.attributes.name,
-                                        node.attributes().sdfg.sdfg_list_id
+                                        node.attributes().sdfg.cfg_list_id
                                     );
                             }
                             // Connectors
@@ -1984,7 +1984,7 @@ export class SDFGRenderer extends EventEmitter {
 
         // Start with top-level SDFG.
         traverseRecursive(
-            this.graph, this.sdfg.attributes.name, this.sdfg.sdfg_list_id
+            this.graph, this.sdfg.attributes.name, this.sdfg.cfg_list_id
         );
     }
 
@@ -2322,7 +2322,7 @@ export class SDFGRenderer extends EventEmitter {
                                     // Do not move connectors (individually)
                                     if (el instanceof Connector)
                                         return false;
-                                    const list_id = el.sdfg.sdfg_list_id;
+                                    const list_id = el.sdfg.cfg_list_id;
 
                                     // Do not move element individually if it is
                                     // moved together with a nested SDFG
@@ -2337,7 +2337,7 @@ export class SDFGRenderer extends EventEmitter {
                                     // Do not move element individually if it is
                                     // moved together with its parent state
                                     const state_parent =
-                                        this.sdfg_list[list_id].node(
+                                        this.cfg_list[list_id].node(
                                             el.parent_id!.toString()
                                         );
                                     if (state_parent &&
@@ -2357,7 +2357,7 @@ export class SDFGRenderer extends EventEmitter {
                             if (old_mousepos)
                                 this.canvas_manager?.translate_element(
                                     el, old_mousepos, this.mousepos,
-                                    this.graph, this.sdfg_list,
+                                    this.graph, this.cfg_list,
                                     this.state_parent_list,
                                     this.drag_start,
                                     true,
@@ -2577,7 +2577,7 @@ export class SDFGRenderer extends EventEmitter {
                 // nested sdfg
                 if (intersected && obj instanceof AccessNode) {
                     traverseSDFGScopes(
-                        this.sdfg_list[obj.sdfg.sdfg_list_id],
+                        this.cfg_list[obj.sdfg.cfg_list_id],
                         (node: any) => {
                             // If node is a state, then visit sub-scope
                             if (node instanceof State)
@@ -2894,7 +2894,7 @@ export class SDFGRenderer extends EventEmitter {
                             // Move it to original position
                             this.canvas_manager?.translate_element(
                                 edge_el, { x: 0, y: 0 }, { x: 0, y: 0 },
-                                this.graph, this.sdfg_list,
+                                this.graph, this.cfg_list,
                                 this.state_parent_list, undefined, false, false,
                                 new_points
                             );
@@ -2916,7 +2916,7 @@ export class SDFGRenderer extends EventEmitter {
                             this.canvas_manager?.translate_element(
                                 el, { x: el.x, y: el.y },
                                 { x: new_x, y: new_y }, this.graph,
-                                this.sdfg_list, this.state_parent_list,
+                                this.cfg_list, this.state_parent_list,
                                 undefined, false, false, undefined
                             );
 
@@ -3159,15 +3159,15 @@ export class SDFGRenderer extends EventEmitter {
          */
         // Collect nodes and states
         const sdfgs: Set<number> = new Set<number>();
-        const sdfg_list: { [key: string]: JsonSDFG } = {};
+        const cfg_list: { [key: string]: JsonSDFG } = {};
         const states: { [key: string]: Array<number> } = {};
         const nodes: { [key: string]: Array<number> } = {};
         for (const elem of this.selected_elements) {
             // Ignore edges and connectors
             if (elem instanceof Edge || elem instanceof Connector)
                 continue;
-            const sdfg_id = elem.sdfg.sdfg_list_id;
-            sdfg_list[sdfg_id] = elem.sdfg;
+            const sdfg_id = elem.sdfg.cfg_list_id;
+            cfg_list[sdfg_id] = elem.sdfg;
             sdfgs.add(sdfg_id);
             let state_id: number = -1;
             if (elem.parent_id !== null) {
@@ -3203,20 +3203,20 @@ export class SDFGRenderer extends EventEmitter {
         // Find root SDFG and root state (if possible)
         const root_sdfg_id = find_root_sdfg(sdfgs, this.sdfg_tree);
         if (root_sdfg_id !== null) {
-            const root_sdfg = sdfg_list[root_sdfg_id];
+            const root_sdfg = cfg_list[root_sdfg_id];
 
             // For every participating state, filter out irrelevant nodes and
             // memlets.
             for (const nkey of Object.keys(nodes)) {
                 const [sdfg_id, state_id] = JSON.parse(nkey);
-                const sdfg = sdfg_list[sdfg_id];
+                const sdfg = cfg_list[sdfg_id];
                 delete_sdfg_nodes(sdfg, state_id, nodes[nkey], true);
             }
 
             // For every participating SDFG, filter out irrelevant states and
             // interstate edges.
             for (const sdfg_id of Object.keys(states)) {
-                const sdfg = sdfg_list[sdfg_id];
+                const sdfg = cfg_list[sdfg_id];
                 delete_sdfg_states(sdfg, states[sdfg_id], true);
             }
 
@@ -3301,7 +3301,7 @@ type StateMachineType = {
 
 function relayoutStateMachine(
     ctx: CanvasRenderingContext2D, stateMachine: StateMachineType,
-    sdfg: JsonSDFG, sdfgList: SDFGListType, stateParentList: any[],
+    sdfg: JsonSDFG, sdfgList: CFGListType, stateParentList: any[],
     omitAccessNodes: boolean, parent?: SDFGElement
 ): DagreSDFG {
     const BLOCK_MARGIN = 3 * SDFV.LINEHEIGHT;
@@ -3408,7 +3408,7 @@ function relayoutStateMachine(
         // Fall back to dagre for anything that cannot be laid out with
         // the vertical layout (e.g., irreducible control flow).
         try {
-            SMLayouter.layoutDagreCompat(g, sdfg.start_state?.toString());
+            SMLayouter.layoutDagreCompat(g, sdfg.start_block?.toString());
         } catch (_ignored) {
             dagre.layout(g);
         }
@@ -3481,7 +3481,7 @@ function relayoutStateMachine(
     (g as any).height = bb.height;
 
     // Add SDFG to global store.
-    sdfgList[sdfg.sdfg_list_id] = g;
+    sdfgList[sdfg.cfg_list_id] = g;
 
     return g;
 }
@@ -3578,7 +3578,7 @@ function relayoutSDFGState(
         if ((node.type === SDFGElementType.NestedSDFG ||
              node.type === SDFGElementType.ExternalNestedSDFG) &&
             node.attributes.sdfg && node.attributes.sdfg.type !== 'SDFGShell')
-            stateParentList[node.attributes.sdfg.sdfg_list_id] = obj;
+            stateParentList[node.attributes.sdfg.cfg_list_id] = obj;
 
         // Add input connectors.
         let i = 0;

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -1685,7 +1685,7 @@ export class ScopeNode extends SDFGNode {
     public schedule_label(): string {
         let attrs = this.attributes();
         if (this.scopeend() && this.parent_id !== null) {
-            const entry = this.sdfg.nodes[this.parent_id].nodes[
+            const entry = this.parentElem?.data.state.nodes[
                 this.data.node.scope_entry
             ];
             if (entry !== undefined)
@@ -1715,7 +1715,7 @@ export class ScopeNode extends SDFGNode {
 
         let attrs = this.attributes();
         if (this.scopeend() && this.parent_id !== null) {
-            const entry = this.sdfg.nodes[this.parent_id].nodes[
+            const entry = this.parentElem?.data.state.nodes[
                 this.data.node.scope_entry
             ];
             if (entry !== undefined)
@@ -1753,7 +1753,7 @@ export class ScopeNode extends SDFGNode {
 
         let result = '';
         if (this.scopeend() && this.parent_id !== null) {
-            const entry = this.sdfg.nodes[this.parent_id].nodes[
+            const entry = this.parentElem?.data.state.nodes[
                 this.data.node.scope_entry
             ];
             if (entry !== undefined)

--- a/src/sdfv.ts
+++ b/src/sdfv.ts
@@ -29,7 +29,7 @@ import {
     State
 } from './renderer/renderer_elements';
 import { htmlSanitize } from './utils/sanitization';
-import { parse_sdfg, stringify_sdfg } from './utils/sdfg/json_serializer';
+import { checkCompatLoad, parse_sdfg, stringify_sdfg } from './utils/sdfg/json_serializer';
 import { SDFVSettings } from './utils/sdfv_settings';
 
 declare const vscode: any;
@@ -503,7 +503,7 @@ function file_read_complete(sdfv: SDFV): void {
     const result_string = fr.result;
     const container = document.getElementById('contents');
     if (result_string && container) {
-        const sdfg = parse_sdfg(result_string);
+        const sdfg = checkCompatLoad(parse_sdfg(result_string));
         sdfv.get_renderer()?.destroy();
         sdfv.set_renderer(new SDFGRenderer(sdfv, sdfg, container, mouse_event));
         sdfv.close_menu();
@@ -632,7 +632,7 @@ function load_sdfg_from_url(sdfv: SDFV, url: string): void {
     request.responseType = 'text'; // Will be parsed as JSON by parse_sdfg
     request.onload = () => {
         if (request.status === 200) {
-            const sdfg = parse_sdfg(request.response);
+            const sdfg = checkCompatLoad(parse_sdfg(request.response));
             sdfv.get_renderer()?.destroy();
             init_sdfv(sdfg, null, false, null);
         } else {

--- a/src/sdfv.ts
+++ b/src/sdfv.ts
@@ -180,7 +180,7 @@ export class SDFV {
 
             // If a scope has children, remove the name "Entry" from the type
             if (node.type().endsWith('Entry') && node.parent_id && node.id) {
-                const state = node.sdfg.nodes[node.parent_id];
+                const state = node.parentElem?.data.state.nodes[node.parent_id];
                 if (state.scope_dict[node.id] !== undefined) {
                     node_type = node_type.slice(0, -5);
                 }
@@ -194,7 +194,9 @@ export class SDFV {
                 const nodes_to_display = [node];
                 if (node.type().endsWith('Entry') && node.parent_id &&
                     node.id) {
-                    const state = node.sdfg.nodes[node.parent_id];
+                    const state = node.parentElem?.data.state.nodes[
+                        node.parent_id
+                    ];
                     if (state.scope_dict[node.id] !== undefined) {
                         for (const subnode_id of state.scope_dict[node.id])
                             nodes_to_display.push(parent.node(subnode_id));
@@ -241,7 +243,7 @@ export class SDFV {
         contents.html('');
 
         if (elem instanceof Memlet && elem.parent_id && elem.id) {
-            const sdfg_edge = elem.sdfg.nodes[elem.parent_id].edges[elem.id];
+            const sdfg_edge = elem.parentElem?.data.state.edges[elem.id];
             contents.append($('<h4>', {
                 html: 'Connectors: ' + sdfg_edge.src_connector + ' &rarr; ' +
                     sdfg_edge.dst_connector,

--- a/src/sdfv.ts
+++ b/src/sdfv.ts
@@ -731,16 +731,16 @@ export function find_in_graph(
 }
 
 function recursive_find_graph(
-    graph: DagreSDFG, sdfg_id: number
+    graph: DagreSDFG, cfg_id: number
 ): DagreSDFG | undefined {
     let found = undefined;
     for (const n_id of graph.nodes()) {
         const n = graph.node(n_id);
-        if (n && n.sdfg.sdfg_list_id === sdfg_id) {
+        if (n && n.sdfg.cfg_list_id === cfg_id) {
             found = graph;
             return found;
         } else if (n && n.data.graph) {
-            found = recursive_find_graph(n.data.graph, sdfg_id);
+            found = recursive_find_graph(n.data.graph, cfg_id);
             if (found)
                 return found;
         }

--- a/src/utils/sdfg/sdfg_utils.ts
+++ b/src/utils/sdfg/sdfg_utils.ts
@@ -20,7 +20,7 @@ export function recursively_find_graph(
     graph_id: number,
     ns_node: SDFGNode | undefined = undefined
 ): { graph: DagreSDFG | undefined, node: SDFGNode | undefined } {
-    if (graph.node('0').sdfg.sdfg_list_id === graph_id) {
+    if (graph.node('0').sdfg.cfg_list_id === graph_id) {
         return {
             graph: graph,
             node: ns_node,
@@ -80,14 +80,14 @@ export function get_uuid_graph_element(element: SDFGElement | null): string {
     const undefined_val = -1;
     if (element instanceof State) {
         return (
-            element.sdfg.sdfg_list_id + '/' +
+            element.sdfg.cfg_list_id + '/' +
             element.id + '/' +
             undefined_val + '/' +
             undefined_val
         );
     } else if (element instanceof SDFGNode) {
         return (
-            element.sdfg.sdfg_list_id + '/' +
+            element.sdfg.cfg_list_id + '/' +
             element.parent_id + '/' +
             element.id + '/' +
             undefined_val
@@ -97,7 +97,7 @@ export function get_uuid_graph_element(element: SDFGElement | null): string {
         if (element.parent_id !== null && element.parent_id !== undefined)
             parent_id = element.parent_id;
         return (
-            element.sdfg.sdfg_list_id + '/' +
+            element.sdfg.cfg_list_id + '/' +
             parent_id + '/' +
             undefined_val + '/' +
             element.id
@@ -380,8 +380,8 @@ export function delete_sdfg_states(
         e.src = mapping[e.src];
         e.dst = mapping[e.dst];
     });
-    if (mapping[sdfg.start_state] === '-1')
-        sdfg.start_state = 0;
+    if (mapping[sdfg.start_block] === '-1')
+        sdfg.start_block = 0;
     else
-        sdfg.start_state = parseInt(mapping[sdfg.start_state]);
+        sdfg.start_block = parseInt(mapping[sdfg.start_block]);
 }

--- a/src/utils/sdfg/traversal.ts
+++ b/src/utils/sdfg/traversal.ts
@@ -48,7 +48,7 @@ import {
                 // Traverse scopes recursively (if scope_dict provided).
                 if (node.type().endsWith('Entry') && node.parent_id !== null &&
                     node.id !== null) {
-                    const state = node.sdfg.nodes[node.parent_id];
+                    const state = node.parentElem?.data.state;
                     if (state.scope_dict[node.id] !== undefined)
                         scopesRecursive(
                             graph, state.scope_dict[node.id], processedNodes

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -145,13 +145,13 @@ export function get_element_uuid(element: SDFGElement): string {
     const undefined_val = -1;
     if (element instanceof State) {
         return (
-            element.sdfg.sdfg_list_id + '/' +
+            element.sdfg.cfg_list_id + '/' +
             element.id + '/' +
             undefined_val + '/' +
             undefined_val
         );
     } else if (element instanceof NestedSDFG) {
-        const sdfg_id = element.data.node.attributes.sdfg.sdfg_list_id;
+        const sdfg_id = element.data.node.attributes.sdfg.cfg_list_id;
         return (
             sdfg_id + '/' +
             undefined_val + '/' +
@@ -162,14 +162,14 @@ export function get_element_uuid(element: SDFGElement): string {
         // For MapExit nodes, we want to get the uuid of the corresponding
         // entry node instead.
         return (
-            element.sdfg.sdfg_list_id + '/' +
+            element.sdfg.cfg_list_id + '/' +
             element.parent_id + '/' +
             element.data.node.scope_entry + '/' +
             undefined_val
         );
     } else if (element instanceof SDFGNode) {
         return (
-            element.sdfg.sdfg_list_id + '/' +
+            element.sdfg.cfg_list_id + '/' +
             element.parent_id + '/' +
             element.id + '/' +
             undefined_val


### PR DESCRIPTION
Make the viewer compatible with migrations to hierarchical CFG SDFGs and sdfg_list to cfg_list refactorings. The PR adds a compatibility checker that converts SDFGs with versions pre DaCe 0.16.0 on-the-fly to visualize properly, and upon saving automatically converts back to not drop compatibility of older dace versions.