### PR TITLE
Edges and Overlays Optimizations

### DIFF
--- a/src/overlays/avg_parallelism_overlay.ts
+++ b/src/overlays/avg_parallelism_overlay.ts
@@ -208,8 +208,9 @@ export class AvgParallelismOverlay extends GenericSdfgOverlay {
             ))
                 return;
 
+            const stateppp = Math.sqrt(state.width * state.height) / ppp;
             if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                state.width / ppp <= SDFV.STATE_LOD)) ||
+                stateppp <= SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 this.shade_node(state, ctx);
             } else {

--- a/src/overlays/avg_parallelism_overlay.ts
+++ b/src/overlays/avg_parallelism_overlay.ts
@@ -209,8 +209,7 @@ export class AvgParallelismOverlay extends GenericSdfgOverlay {
                 return;
 
             const stateppp = Math.sqrt(state.width * state.height) / ppp;
-            if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                stateppp <= SDFV.STATE_LOD)) ||
+            if (((ctx as any).lod && (stateppp < SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 this.shade_node(state, ctx);
             } else {
@@ -224,19 +223,19 @@ export class AvgParallelismOverlay extends GenericSdfgOverlay {
                             visible_rect.y, visible_rect.w, visible_rect.h))
                             return;
 
-                        if (node.data.node.attributes.is_collapsed ||
-                            ((ctx as any).lod && ppp >= SDFV.NODE_LOD)) {
-                            this.shade_node(node, ctx);
-                        } else {
-                            if (node instanceof NestedSDFG &&
-                                node.attributes().sdfg &&
-                                node.attributes().sdfg.type !== 'SDFGShell') {
+                        if (node instanceof NestedSDFG && !node.data.node.attributes.is_collapsed) {
+                            const nodeppp = Math.sqrt(node.width * node.height) / ppp;
+                            if ((ctx as any).lod && nodeppp < SDFV.STATE_LOD) {
+                                this.shade_node(node, ctx);
+                            }
+                            else if (node.attributes().sdfg && node.attributes().sdfg.type !== 'SDFGShell') {
                                 this.recursively_shade_sdfg(
                                     node.data.graph, ctx, ppp, visible_rect
                                 );
-                            } else {
-                                this.shade_node(node, ctx);
                             }
+                        }
+                        else {
+                            this.shade_node(node, ctx);
                         }
                     });
                 }

--- a/src/overlays/depth_overlay.ts
+++ b/src/overlays/depth_overlay.ts
@@ -225,7 +225,7 @@ export class DepthOverlay extends GenericSdfgOverlay {
                             return;
 
                         if (node.data.node.attributes.is_collapsed ||
-                            ((ctx as any).lod && ppp >= SDFV.NODE_LOD)) {
+                            ((ctx as any).lod && ppp > SDFV.NODE_LOD)) {
                             this.shade_node(node, ctx);
                         } else {
                             if (node instanceof NestedSDFG &&

--- a/src/overlays/depth_overlay.ts
+++ b/src/overlays/depth_overlay.ts
@@ -208,8 +208,9 @@ export class DepthOverlay extends GenericSdfgOverlay {
             ))
                 return;
 
+            const stateppp = Math.sqrt(state.width * state.height) / ppp;
             if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                state.width / ppp <= SDFV.STATE_LOD)) ||
+                stateppp <= SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 this.shade_node(state, ctx);
             } else {

--- a/src/overlays/depth_overlay.ts
+++ b/src/overlays/depth_overlay.ts
@@ -209,8 +209,7 @@ export class DepthOverlay extends GenericSdfgOverlay {
                 return;
 
             const stateppp = Math.sqrt(state.width * state.height) / ppp;
-            if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                stateppp <= SDFV.STATE_LOD)) ||
+            if (((ctx as any).lod && (stateppp < SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 this.shade_node(state, ctx);
             } else {
@@ -224,19 +223,19 @@ export class DepthOverlay extends GenericSdfgOverlay {
                             visible_rect.y, visible_rect.w, visible_rect.h))
                             return;
 
-                        if (node.data.node.attributes.is_collapsed ||
-                            ((ctx as any).lod && ppp > SDFV.NODE_LOD)) {
-                            this.shade_node(node, ctx);
-                        } else {
-                            if (node instanceof NestedSDFG &&
-                                node.attributes().sdfg &&
-                                node.attributes().sdfg.type !== 'SDFGShell') {
+                        if (node instanceof NestedSDFG && !node.data.node.attributes.is_collapsed) {
+                            const nodeppp = Math.sqrt(node.width * node.height) / ppp;
+                            if ((ctx as any).lod && nodeppp < SDFV.STATE_LOD) {
+                                this.shade_node(node, ctx);
+                            }
+                            else if (node.attributes().sdfg && node.attributes().sdfg.type !== 'SDFGShell') {
                                 this.recursively_shade_sdfg(
                                     node.data.graph, ctx, ppp, visible_rect
                                 );
-                            } else {
-                                this.shade_node(node, ctx);
                             }
+                        }
+                        else {
+                            this.shade_node(node, ctx);
                         }
                     });
                 }

--- a/src/overlays/logical_group_overlay.ts
+++ b/src/overlays/logical_group_overlay.ts
@@ -127,7 +127,7 @@ export class LogicalGroupOverlay extends GenericSdfgOverlay {
                                 return;
 
                             if (node.attributes().is_collapsed ||
-                                ((ctx as any).lod && ppp >= SDFV.NODE_LOD)) {
+                                ((ctx as any).lod && ppp > SDFV.NODE_LOD)) {
                                 this.shade_node(node, sdfgGroups, ctx);
                             } else {
                                 if (node instanceof NestedSDFG &&

--- a/src/overlays/logical_group_overlay.ts
+++ b/src/overlays/logical_group_overlay.ts
@@ -105,8 +105,9 @@ export class LogicalGroupOverlay extends GenericSdfgOverlay {
             ))
                 return;
 
+            const blockppp = Math.sqrt(block.width * block.height) / ppp;
             if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                block.width / ppp <= SDFV.STATE_LOD)) ||
+                blockppp <= SDFV.STATE_LOD)) ||
                 block.attributes().is_collapsed
             ) {
                 this.shade_node(block, sdfgGroups, ctx);

--- a/src/overlays/logical_group_overlay.ts
+++ b/src/overlays/logical_group_overlay.ts
@@ -91,6 +91,10 @@ export class LogicalGroupOverlay extends GenericSdfgOverlay {
         if (sdfgGroups === undefined)
             return;
 
+        if (!graph) {
+            return;
+        }
+
         graph.nodes().forEach(v => {
             const block = graph.node(v);
 

--- a/src/overlays/logical_group_overlay.ts
+++ b/src/overlays/logical_group_overlay.ts
@@ -88,8 +88,9 @@ export class LogicalGroupOverlay extends GenericSdfgOverlay {
         // In that case, we overlay the correct grouping color(s).
         // If it's expanded or zoomed in close enough, we traverse inside.
         const sdfgGroups = sdfg.attributes.logical_groups;
-        if (sdfgGroups === undefined)
+        if (sdfgGroups === undefined || sdfgGroups.length === 0) {    
             return;
+        }
 
         if (!graph) {
             return;

--- a/src/overlays/logical_group_overlay.ts
+++ b/src/overlays/logical_group_overlay.ts
@@ -107,8 +107,7 @@ export class LogicalGroupOverlay extends GenericSdfgOverlay {
                 return;
 
             const blockppp = Math.sqrt(block.width * block.height) / ppp;
-            if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                blockppp <= SDFV.STATE_LOD)) ||
+            if (((ctx as any).lod && (blockppp < SDFV.STATE_LOD)) ||
                 block.attributes().is_collapsed
             ) {
                 this.shade_node(block, sdfgGroups, ctx);

--- a/src/overlays/memory_location_overlay.ts
+++ b/src/overlays/memory_location_overlay.ts
@@ -240,6 +240,7 @@ export class MemoryLocationOverlay extends GenericSdfgOverlay {
             const stateppp = Math.sqrt(state.width * state.height) / ppp;
             if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
                 stateppp <= SDFV.STATE_LOD)) ||
+                // TODO: For all overlays: handle LoopRegions, which don't have the state.data.state attribute
                 state.data.state.attributes.is_collapsed) {
                 // The state is collapsed or invisible, so we don't need to
                 // traverse its insides.

--- a/src/overlays/memory_location_overlay.ts
+++ b/src/overlays/memory_location_overlay.ts
@@ -238,11 +238,10 @@ export class MemoryLocationOverlay extends GenericSdfgOverlay {
                 return;
 
             const stateppp = Math.sqrt(state.width * state.height) / ppp;
-            if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                stateppp <= SDFV.STATE_LOD)) ||
+            if (((ctx as any).lod && (stateppp < SDFV.STATE_LOD)) ||
                 // TODO: For all overlays: handle LoopRegions, which don't have the state.data.state attribute
                 state.data.state.attributes.is_collapsed) {
-                // The state is collapsed or invisible, so we don't need to
+                // The state is collapsed or too small, so we don't need to
                 // traverse its insides.
                 return;
             } else {

--- a/src/overlays/memory_location_overlay.ts
+++ b/src/overlays/memory_location_overlay.ts
@@ -237,8 +237,9 @@ export class MemoryLocationOverlay extends GenericSdfgOverlay {
             ))
                 return;
 
+            const stateppp = Math.sqrt(state.width * state.height) / ppp;
             if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                state.width / ppp <= SDFV.STATE_LOD)) ||
+                stateppp <= SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 // The state is collapsed or invisible, so we don't need to
                 // traverse its insides.
@@ -261,7 +262,9 @@ export class MemoryLocationOverlay extends GenericSdfgOverlay {
                                 node.data.graph, ctx, ppp, visibleRect
                             );
                         } else if (node instanceof AccessNode) {
-                            this.shadeNode(node, ctx);
+                            if (!(ctx as any).lod || ppp < SDFV.NODE_LOD) {
+                                this.shadeNode(node, ctx);
+                            }
                         }
                     });
                 }

--- a/src/overlays/memory_volume_overlay.ts
+++ b/src/overlays/memory_volume_overlay.ts
@@ -172,9 +172,7 @@ export class MemoryVolumeOverlay extends GenericSdfgOverlay {
             // If we're zoomed out enough that the contents aren't visible, we
             // skip the state.
             const stateppp = Math.sqrt(state.width * state.height) / ppp;
-            if ((ctx as any).lod && (
-                ppp >= SDFV.STATE_LOD || stateppp < SDFV.STATE_LOD
-            ))
+            if ((ctx as any).lod && (stateppp < SDFV.STATE_LOD))
                 return;
 
 

--- a/src/overlays/memory_volume_overlay.ts
+++ b/src/overlays/memory_volume_overlay.ts
@@ -193,7 +193,7 @@ export class MemoryVolumeOverlay extends GenericSdfgOverlay {
                     // If we're zoomed out enough that the node's contents
                     // aren't visible or the node is collapsed, we skip it.
                     if (node.data.node.attributes.is_collapsed ||
-                        ((ctx as any).lod && ppp >= SDFV.NODE_LOD))
+                        ((ctx as any).lod && ppp > SDFV.NODE_LOD))
                         return;
 
                     if (node instanceof NestedSDFG &&

--- a/src/overlays/operational_intensity_overlay.ts
+++ b/src/overlays/operational_intensity_overlay.ts
@@ -253,8 +253,7 @@ export class OperationalIntensityOverlay extends GenericSdfgOverlay {
                 return;
 
             const stateppp = Math.sqrt(state.width * state.height) / ppp;
-            if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                stateppp <= SDFV.STATE_LOD)) ||
+            if (((ctx as any).lod && (stateppp < SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 this.shade_node(state, ctx);
             } else {
@@ -268,19 +267,19 @@ export class OperationalIntensityOverlay extends GenericSdfgOverlay {
                             visible_rect.y, visible_rect.w, visible_rect.h))
                             return;
 
-                        if (node.data.node.attributes.is_collapsed ||
-                            ((ctx as any).lod && ppp > SDFV.NODE_LOD)) {
-                            this.shade_node(node, ctx);
-                        } else {
-                            if (node instanceof NestedSDFG &&
-                                node.attributes().sdfg &&
-                                node.attributes().sdfg.type !== 'SDFGShell') {
+                        if (node instanceof NestedSDFG && !node.data.node.attributes.is_collapsed) {
+                            const nodeppp = Math.sqrt(node.width * node.height) / ppp;
+                            if ((ctx as any).lod && nodeppp < SDFV.STATE_LOD) {
+                                this.shade_node(node, ctx);
+                            }
+                            else if (node.attributes().sdfg && node.attributes().sdfg.type !== 'SDFGShell') {
                                 this.recursively_shade_sdfg(
                                     node.data.graph, ctx, ppp, visible_rect
                                 );
-                            } else {
-                                this.shade_node(node, ctx);
                             }
+                        }
+                        else {
+                            this.shade_node(node, ctx);
                         }
                     });
                 }

--- a/src/overlays/operational_intensity_overlay.ts
+++ b/src/overlays/operational_intensity_overlay.ts
@@ -269,7 +269,7 @@ export class OperationalIntensityOverlay extends GenericSdfgOverlay {
                             return;
 
                         if (node.data.node.attributes.is_collapsed ||
-                            ((ctx as any).lod && ppp >= SDFV.NODE_LOD)) {
+                            ((ctx as any).lod && ppp > SDFV.NODE_LOD)) {
                             this.shade_node(node, ctx);
                         } else {
                             if (node instanceof NestedSDFG &&

--- a/src/overlays/operational_intensity_overlay.ts
+++ b/src/overlays/operational_intensity_overlay.ts
@@ -252,8 +252,9 @@ export class OperationalIntensityOverlay extends GenericSdfgOverlay {
             ))
                 return;
 
+            const stateppp = Math.sqrt(state.width * state.height) / ppp;
             if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                state.width / ppp <= SDFV.STATE_LOD)) ||
+                stateppp <= SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 this.shade_node(state, ctx);
             } else {

--- a/src/overlays/runtime_micro_seconds_overlay.ts
+++ b/src/overlays/runtime_micro_seconds_overlay.ts
@@ -129,8 +129,9 @@ export class RuntimeMicroSecondsOverlay extends RuntimeReportOverlay {
             ))
                 return;
 
+            const stateppp = Math.sqrt(state.width * state.height) / ppp;
             if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                state.width / ppp <= SDFV.STATE_LOD)) ||
+                stateppp <= SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 this.shade_node(state, ctx);
             } else {

--- a/src/overlays/runtime_micro_seconds_overlay.ts
+++ b/src/overlays/runtime_micro_seconds_overlay.ts
@@ -130,8 +130,7 @@ export class RuntimeMicroSecondsOverlay extends RuntimeReportOverlay {
                 return;
 
             const stateppp = Math.sqrt(state.width * state.height) / ppp;
-            if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                stateppp <= SDFV.STATE_LOD)) ||
+            if (((ctx as any).lod && (stateppp < SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 this.shade_node(state, ctx);
             } else {
@@ -145,19 +144,19 @@ export class RuntimeMicroSecondsOverlay extends RuntimeReportOverlay {
                             visible_rect.y, visible_rect.w, visible_rect.h))
                             return;
 
-                        if (node.data.node.attributes.is_collapsed ||
-                            ((ctx as any).lod && ppp > SDFV.NODE_LOD)) {
-                            this.shade_node(node, ctx);
-                        } else {
-                            if (node instanceof NestedSDFG &&
-                                node.attributes().sdfg &&
-                                node.attributes().sdfg.type !== 'SDFGShell') {
+                        if (node instanceof NestedSDFG && !node.data.node.attributes.is_collapsed) {
+                            const nodeppp = Math.sqrt(node.width * node.height) / ppp;
+                            if ((ctx as any).lod && nodeppp < SDFV.STATE_LOD) {
+                                this.shade_node(node, ctx);
+                            }
+                            else if (node.attributes().sdfg && node.attributes().sdfg.type !== 'SDFGShell') {
                                 this.recursively_shade_sdfg(
                                     node.data.graph, ctx, ppp, visible_rect
                                 );
-                            } else {
-                                this.shade_node(node, ctx);
                             }
+                        }
+                        else {
+                            this.shade_node(node, ctx);
                         }
                     });
                 }

--- a/src/overlays/runtime_micro_seconds_overlay.ts
+++ b/src/overlays/runtime_micro_seconds_overlay.ts
@@ -146,7 +146,7 @@ export class RuntimeMicroSecondsOverlay extends RuntimeReportOverlay {
                             return;
 
                         if (node.data.node.attributes.is_collapsed ||
-                            ((ctx as any).lod && ppp >= SDFV.NODE_LOD)) {
+                            ((ctx as any).lod && ppp > SDFV.NODE_LOD)) {
                             this.shade_node(node, ctx);
                         } else {
                             if (node instanceof NestedSDFG &&

--- a/src/overlays/simulated_operational_intensity_overlay.ts
+++ b/src/overlays/simulated_operational_intensity_overlay.ts
@@ -226,7 +226,7 @@ export class SimulatedOperationalIntensityOverlay extends GenericSdfgOverlay {
                             return;
 
                         if (node.data.node.attributes.is_collapsed ||
-                            ((ctx as any).lod && ppp >= SDFV.NODE_LOD)) {
+                            ((ctx as any).lod && ppp > SDFV.NODE_LOD)) {
                             this.shade_node(node, ctx);
                         } else {
                             if (node instanceof NestedSDFG &&

--- a/src/overlays/simulated_operational_intensity_overlay.ts
+++ b/src/overlays/simulated_operational_intensity_overlay.ts
@@ -210,8 +210,7 @@ export class SimulatedOperationalIntensityOverlay extends GenericSdfgOverlay {
                 return;
 
             const stateppp = Math.sqrt(state.width * state.height) / ppp;
-            if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                stateppp <= SDFV.STATE_LOD)) ||
+            if (((ctx as any).lod && (stateppp < SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 this.shade_node(state, ctx);
             } else {
@@ -225,19 +224,19 @@ export class SimulatedOperationalIntensityOverlay extends GenericSdfgOverlay {
                             visible_rect.y, visible_rect.w, visible_rect.h))
                             return;
 
-                        if (node.data.node.attributes.is_collapsed ||
-                            ((ctx as any).lod && ppp > SDFV.NODE_LOD)) {
-                            this.shade_node(node, ctx);
-                        } else {
-                            if (node instanceof NestedSDFG &&
-                                node.attributes().sdfg &&
-                                node.attributes().sdfg.type !== 'SDFGShell') {
+                        if (node instanceof NestedSDFG && !node.data.node.attributes.is_collapsed) {
+                            const nodeppp = Math.sqrt(node.width * node.height) / ppp;
+                            if ((ctx as any).lod && nodeppp < SDFV.STATE_LOD) {
+                                this.shade_node(node, ctx);
+                            }
+                            else if (node.attributes().sdfg && node.attributes().sdfg.type !== 'SDFGShell') {
                                 this.recursively_shade_sdfg(
                                     node.data.graph, ctx, ppp, visible_rect
                                 );
-                            } else {
-                                this.shade_node(node, ctx);
                             }
+                        }
+                        else {
+                            this.shade_node(node, ctx);
                         }
                     });
                 }

--- a/src/overlays/simulated_operational_intensity_overlay.ts
+++ b/src/overlays/simulated_operational_intensity_overlay.ts
@@ -209,8 +209,9 @@ export class SimulatedOperationalIntensityOverlay extends GenericSdfgOverlay {
             ))
                 return;
 
+            const stateppp = Math.sqrt(state.width * state.height) / ppp;
             if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                state.width / ppp <= SDFV.STATE_LOD)) ||
+                stateppp <= SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 this.shade_node(state, ctx);
             } else {

--- a/src/overlays/static_flops_overlay.ts
+++ b/src/overlays/static_flops_overlay.ts
@@ -225,7 +225,7 @@ export class StaticFlopsOverlay extends GenericSdfgOverlay {
                             return;
 
                         if (node.data.node.attributes.is_collapsed ||
-                            ((ctx as any).lod && ppp >= SDFV.NODE_LOD)) {
+                            ((ctx as any).lod && ppp > SDFV.NODE_LOD)) {
                             this.shade_node(node, ctx);
                         } else {
                             if (node instanceof NestedSDFG &&

--- a/src/overlays/static_flops_overlay.ts
+++ b/src/overlays/static_flops_overlay.ts
@@ -209,8 +209,7 @@ export class StaticFlopsOverlay extends GenericSdfgOverlay {
                 return;
 
             const stateppp = Math.sqrt(state.width * state.height) / ppp;
-            if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                stateppp <= SDFV.STATE_LOD)) ||
+            if (((ctx as any).lod && (stateppp < SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 this.shade_node(state, ctx);
             } else {
@@ -224,19 +223,19 @@ export class StaticFlopsOverlay extends GenericSdfgOverlay {
                             visible_rect.y, visible_rect.w, visible_rect.h))
                             return;
 
-                        if (node.data.node.attributes.is_collapsed ||
-                            ((ctx as any).lod && ppp > SDFV.NODE_LOD)) {
-                            this.shade_node(node, ctx);
-                        } else {
-                            if (node instanceof NestedSDFG &&
-                                node.attributes().sdfg &&
-                                node.attributes().sdfg.type !== 'SDFGShell') {
+                        if (node instanceof NestedSDFG && !node.data.node.attributes.is_collapsed) {
+                            const nodeppp = Math.sqrt(node.width * node.height) / ppp;
+                            if ((ctx as any).lod && nodeppp < SDFV.STATE_LOD) {
+                                this.shade_node(node, ctx);
+                            }
+                            else if (node.attributes().sdfg && node.attributes().sdfg.type !== 'SDFGShell') {
                                 this.recursively_shade_sdfg(
                                     node.data.graph, ctx, ppp, visible_rect
                                 );
-                            } else {
-                                this.shade_node(node, ctx);
                             }
+                        }
+                        else {
+                            this.shade_node(node, ctx);
                         }
                     });
                 }

--- a/src/overlays/static_flops_overlay.ts
+++ b/src/overlays/static_flops_overlay.ts
@@ -208,8 +208,9 @@ export class StaticFlopsOverlay extends GenericSdfgOverlay {
             ))
                 return;
 
+            const stateppp = Math.sqrt(state.width * state.height) / ppp;
             if (((ctx as any).lod && (ppp >= SDFV.STATE_LOD ||
-                state.width / ppp <= SDFV.STATE_LOD)) ||
+                stateppp <= SDFV.STATE_LOD)) ||
                 state.data.state.attributes.is_collapsed) {
                 this.shade_node(state, ctx);
             } else {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -3046,8 +3046,8 @@ export class SDFGRenderer extends EventEmitter {
                         if (obj.hovered && hover_changed) {
                             // Setting these to false will cause the summary symbol 
                             // not to be drawn in renderer_elements.ts
-                            obj.summarise_in_edges = false;
-                            obj.summarise_out_edges = false;
+                            obj.summarize_in_edges = false;
+                            obj.summarize_out_edges = false;
                             const state = obj.parentElem;
                             if (state && state instanceof State && state.data) {
                                 const state_json = state.data.state;
@@ -3063,8 +3063,8 @@ export class SDFGRenderer extends EventEmitter {
                             }
                         }
                         else if (!obj.hovered && hover_changed) {
-                            obj.summarise_in_edges = true;
-                            obj.summarise_out_edges = true;
+                            obj.summarize_in_edges = true;
+                            obj.summarize_out_edges = true;
                             const state = obj.parentElem;
                             if (state && state instanceof State && state.data) {
                                 const state_json = state.data.state;
@@ -4239,17 +4239,17 @@ function relayoutSDFGState(
             return;
         }
         
-        // Summarise edges for NestedSDFGs and ScopeNodes
+        // Summarize edges for NestedSDFGs and ScopeNodes
         if (gnode instanceof NestedSDFG || gnode instanceof ScopeNode) {
             const n_of_in_connectors = gnode.in_connectors.length;
             const n_of_out_connectors = gnode.out_connectors.length;
 
             if (n_of_in_connectors > 10) {
-                gnode.summarise_in_edges = true;
+                gnode.summarize_in_edges = true;
                 gnode.in_summary_has_effect = true;
             }
             if (n_of_out_connectors > 10) {
-                gnode.summarise_out_edges = true;
+                gnode.summarize_out_edges = true;
                 gnode.out_summary_has_effect = true;
             }
         }
@@ -4269,10 +4269,10 @@ function relayoutSDFGState(
             state.edges.forEach((edge: JsonSDFGEdge, id: number) => {
                 if (edge.dst === gnode.id.toString() && edge.dst_connector === c.data.name) {
                 
-                    // If in-edges are to be summarised, set Memlet.summarised
+                    // If in-edges are to be summarized, set Memlet.summarized
                     const gedge = g.edge(edge.src, edge.dst, id.toString()) as Memlet;
-                    if (gedge && gnode.summarise_in_edges) {
-                        gedge.summarised = true;
+                    if (gedge && gnode.summarize_in_edges) {
+                        gedge.summarized = true;
                     }
 
                     const source_node: SDFGNode = g.node(edge.src);
@@ -4313,14 +4313,14 @@ function relayoutSDFGState(
             }
         }
         
-        // For out_connectors set Memlet.summarised for all out-edges if needed
-        if (gnode.summarise_out_edges) {
+        // For out_connectors set Memlet.summarized for all out-edges if needed
+        if (gnode.summarize_out_edges) {
             for (const c of gnode.out_connectors) {
                 state.edges.forEach((edge: JsonSDFGEdge, id: number) => {
                     if (edge.src === gnode.id.toString() && edge.src_connector === c.data.name) {
                         const gedge = g.edge(edge.src, edge.dst, id.toString()) as Memlet;
                         if (gedge) {
-                            gedge.summarised = true;
+                            gedge.summarized = true;
                         }
                     }
                 });

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -59,7 +59,8 @@ import {
     Tasklet,
     drawSDFG,
     offset_sdfg,
-    offset_state
+    offset_state,
+    ScopeNode
 } from './renderer_elements';
 
 // External, non-typescript libraries which are presented as previously loaded
@@ -4132,13 +4133,17 @@ function relayoutSDFGState(
             return;
         }
         
-        const n_of_in_connectors = gnode.in_connectors.length;
-        const n_of_out_connectors = gnode.out_connectors.length;
-        if (n_of_in_connectors > 10) {
-            gnode.summarise_in_edges = true;
-        }
-        if (n_of_out_connectors > 10) {
-            gnode.summarise_out_edges = true;
+        // Summarise edges for NestedSDFGs and ScopeNodes
+        if (gnode instanceof NestedSDFG || gnode instanceof ScopeNode) {
+            const n_of_in_connectors = gnode.in_connectors.length;
+            const n_of_out_connectors = gnode.out_connectors.length;
+
+            if (n_of_in_connectors > 10) {
+                gnode.summarise_in_edges = true;
+            }
+            if (n_of_out_connectors > 10) {
+                gnode.summarise_out_edges = true;
+            }
         }
         
         const SPACING = SDFV.LINEHEIGHT;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -859,6 +859,30 @@ export class SDFGRenderer extends EventEmitter {
         // Create the initial SDFG layout
         // Loading animation already started in the file_read_complete function in sdfv.ts
         // to also include the JSON parsing step.
+        // Initial layout collapsed
+        this.for_all_sdfg_elements(
+            (_t: SDFGElementGroup, _d: any, obj: any) => {
+                if ('is_collapsed' in obj.attributes &&
+                    !obj.type.endsWith('Exit'))
+                    obj.attributes.is_collapsed = true;
+            }
+        );
+        this.emit('collapse_state_changed', true, true);
+
+        this.relayout();
+
+        if (this.graph) {
+            traverseSDFGScopes(
+                this.graph, (node: SDFGNode, _: DagreSDFG) => {
+                    if(node.attributes().is_collapsed) {
+                        node.attributes().is_collapsed = false;
+                        return false;
+                    }
+                    return true;
+                }
+            );
+        }
+        this.emit('collapse_state_changed', false, true);
         this.relayout();
 
         // Set mouse event handlers

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -908,30 +908,6 @@ export class SDFGRenderer extends EventEmitter {
         // Create the initial SDFG layout
         // Loading animation already started in the file_read_complete function in sdfv.ts
         // to also include the JSON parsing step.
-        // Initial layout fully collapsed
-        // this.doForAllSDFGElements(
-        //     (_t: SDFGElementGroup, _d: any, obj: any) => {
-        //         if ('is_collapsed' in obj.attributes &&
-        //             !obj.type.endsWith('Exit'))
-        //             obj.attributes.is_collapsed = true;
-        //     }
-        // );
-        // this.emit('collapse_state_changed', true, true);
-        // this.relayout();
-
-        // // Expand by one level
-        // if (this.graph) {
-        //     traverseSDFGScopes(
-        //         this.graph, (node: SDFGNode, _: DagreGraph) => {
-        //             if(node.attributes().is_collapsed) {
-        //                 node.attributes().is_collapsed = false;
-        //                 return false;
-        //             }
-        //             return true;
-        //         }
-        //     );
-        // }
-        // this.emit('collapse_state_changed', false, true);
         this.relayout();
 
         // Set mouse event handlers
@@ -3119,7 +3095,7 @@ export class SDFGRenderer extends EventEmitter {
                             highlighting_changed = true;
                             hover_changed = true;
                         }
-                        
+ 
                         // Highlight all edges of the memlet tree
                         if (obj instanceof Edge && obj.parent_id !== null) {
                             if (obj.hovered && hover_changed) {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -856,10 +856,12 @@ export class SDFGRenderer extends EventEmitter {
         else
             this.bgcolor = window.getComputedStyle(this.canvas).backgroundColor;
 
+
         // Create the initial SDFG layout
         // Loading animation already started in the file_read_complete function in sdfv.ts
         // to also include the JSON parsing step.
-        // Initial layout collapsed
+        
+        // Initial layout fully collapsed
         this.for_all_sdfg_elements(
             (_t: SDFGElementGroup, _d: any, obj: any) => {
                 if ('is_collapsed' in obj.attributes &&
@@ -868,9 +870,9 @@ export class SDFGRenderer extends EventEmitter {
             }
         );
         this.emit('collapse_state_changed', true, true);
-
         this.relayout();
 
+        // Expand by one level
         if (this.graph) {
             traverseSDFGScopes(
                 this.graph, (node: SDFGNode, _: DagreSDFG) => {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -4216,9 +4216,11 @@ function relayoutSDFGState(
 
             if (n_of_in_connectors > 10) {
                 gnode.summarise_in_edges = true;
+                gnode.in_summary_has_effect = true;
             }
             if (n_of_out_connectors > 10) {
                 gnode.summarise_out_edges = true;
+                gnode.out_summary_has_effect = true;
             }
         }
         

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -4239,12 +4239,11 @@ function relayoutSDFGState(
     const g: DagreGraph = new dagre.graphlib.Graph({ multigraph: true });
 
     // Set layout options and a simpler algorithm for large graphs.
-    const layoutOptions: any = { ranksep: 30 };
+    const layoutOptions: any = { ranksep: SDFV.RANKSEP };
     if (state.nodes.length >= 1000)
         layoutOptions.ranker = 'longest-path';
 
-    layoutOptions.nodesep = 20; // default: 50
-    layoutOptions.ranksep = 70; // default: 50
+    layoutOptions.nodesep = SDFV.NODESEP;
     g.setGraph(layoutOptions);
 
     // Set an object for the graph label.

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -2184,7 +2184,9 @@ export class SDFGRenderer extends EventEmitter {
                     state
                 );
 
-                if (state.data.state.attributes.is_collapsed)
+                if (state instanceof State && state.data.state.attributes.is_collapsed)
+                    return;
+                if (state instanceof LoopRegion && state.data.block.attributes.is_collapsed)
                     return;
 
                 const ng = state.data.graph;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -2819,7 +2819,7 @@ export class SDFGRenderer extends EventEmitter {
                             highlighting_changed = true;
                             hover_changed = true;
                         }
-
+                        
                         // Highlight all edges of the memlet tree
                         if (obj instanceof Edge && obj.parent_id !== null) {
                             if (obj.hovered && hover_changed) {
@@ -2878,6 +2878,44 @@ export class SDFGRenderer extends EventEmitter {
                         }
         
                         if (obj instanceof Connector) {
+                            
+                            // Highlight the incoming/outgoing Edge
+                            const parent_node = obj.linkedElem;
+                            if (obj.hovered && (hover_changed || (!parent_node?.hovered))) {
+                                const state = obj.linkedElem?.parentElem;
+                                if (state && state instanceof State && state.data) {
+                                    const state_json = state.data.state;
+                                    const state_graph = state.data.graph;
+                                    state_json.edges.forEach((edge: JsonSDFGEdge, id: number) => {
+                                        if (edge.src_connector === obj.data.name || edge.dst_connector === obj.data.name) {
+                                            const gedge = state_graph.edge(edge.src, edge.dst, id.toString()) as Memlet;
+                                            if (gedge) {
+                                                gedge.highlighted = true;
+                                            }
+                                        }
+                                    });
+                                }
+                            }
+                            if (!obj.hovered && hover_changed) {
+                                // Prevent de-highlighting of edge if parent is already hovered (to show all edges)
+                                if (parent_node && !parent_node.hovered) {
+                                    const state = obj.linkedElem?.parentElem;
+                                    if (state && state instanceof State && state.data) {
+                                        const state_json = state.data.state;
+                                        const state_graph = state.data.graph;
+                                        state_json.edges.forEach((edge: JsonSDFGEdge, id: number) => {
+                                            if (edge.src_connector === obj.data.name || edge.dst_connector === obj.data.name) {
+                                                const gedge = state_graph.edge(edge.src, edge.dst, id.toString()) as Memlet;
+                                                if (gedge) {
+                                                    gedge.highlighted = false;
+                                                }
+                                            }
+                                        });
+                                    }
+                                }
+                            }
+
+
                             // Highlight all access nodes with the same name as the
                             // hovered connector in the nested sdfg
                             if (obj.hovered && hover_changed) {
@@ -2956,6 +2994,42 @@ export class SDFGRenderer extends EventEmitter {
                                         }
                                     }
                                 }
+                            }
+                        }
+                        
+                        // Make all edges of a node visible and remove the edge summary symbol
+                        if (obj.hovered && hover_changed) {
+                            obj.summarise_in_edges = false;
+                            obj.summarise_out_edges = false;
+                            const state = obj.parentElem;
+                            if (state && state instanceof State && state.data) {
+                                const state_json = state.data.state;
+                                const state_graph = state.data.graph;
+                                state_json.edges.forEach((edge: JsonSDFGEdge, id: number) => {
+                                    if (edge.src === obj.id.toString() || edge.dst === obj.id.toString()) {
+                                        const gedge = state_graph.edge(edge.src, edge.dst, id.toString()) as Memlet;
+                                        if (gedge) {
+                                            gedge.highlighted = true;
+                                        }
+                                    }
+                                });
+                            }
+                        }
+                        else if (!obj.hovered && hover_changed) {
+                            obj.summarise_in_edges = true;
+                            obj.summarise_out_edges = true;
+                            const state = obj.parentElem;
+                            if (state && state instanceof State && state.data) {
+                                const state_json = state.data.state;
+                                const state_graph = state.data.graph;
+                                state_json.edges.forEach((edge: JsonSDFGEdge, id: number) => {
+                                    if (edge.src === obj.id.toString() || edge.dst === obj.id.toString()) {
+                                        const gedge = state_graph.edge(edge.src, edge.dst, id.toString()) as Memlet;
+                                        if (gedge) {
+                                            gedge.highlighted = false;
+                                        }
+                                    }
+                                });
                             }
                         }
                     }

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -2999,6 +2999,8 @@ export class SDFGRenderer extends EventEmitter {
                         
                         // Make all edges of a node visible and remove the edge summary symbol
                         if (obj.hovered && hover_changed) {
+                            // Setting these to false will cause the summary symbol 
+                            // not to be drawn in renderer_elements.ts
                             obj.summarise_in_edges = false;
                             obj.summarise_out_edges = false;
                             const state = obj.parentElem;

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -14,6 +14,12 @@ import {
     JsonSDFGState,
     MemoryLocationOverlay,
     MemoryVolumeOverlay,
+    AvgParallelismOverlay,
+    DepthOverlay,
+    OperationalIntensityOverlay,
+    RuntimeMicroSecondsOverlay,
+    SimulatedOperationalIntensityOverlay,
+    StaticFlopsOverlay,
     ModeButtons,
     Point2D,
     SDFVTooltipFunc,
@@ -219,9 +225,6 @@ export class SDFGRenderer extends EventEmitter {
         this.external_mouse_handler = on_mouse_event;
 
         this.overlay_manager = new OverlayManager(this);
-
-        // Register overlays that are turned on by default.
-        this.overlay_manager.register_overlay(LogicalGroupOverlay);
 
         this.in_vscode = false;
         try {
@@ -552,7 +555,7 @@ export class SDFGRenderer extends EventEmitter {
                 }).appendTo(this.toolbar).append(overlayDropdown);
 
                 const addOverlayToMenu = (
-                    txt: string, ol: typeof GenericSdfgOverlay
+                    txt: string, ol: typeof GenericSdfgOverlay, default_state: boolean
                 ) => {
                     const olItem = $('<li>', {
                         css: {
@@ -565,6 +568,7 @@ export class SDFGRenderer extends EventEmitter {
                     const olInput = $('<input>', {
                         class: 'form-check-input',
                         type: 'checkbox',
+                        checked: default_state,
                         change: () => {
                             if (olInput.prop('checked'))
                                 this.overlay_manager?.register_overlay(ol);
@@ -578,11 +582,20 @@ export class SDFGRenderer extends EventEmitter {
                     }).appendTo(olContainer);
                 };
 
-                addOverlayToMenu('Logical groups', LogicalGroupOverlay);
-                addOverlayToMenu('Storage locations', MemoryLocationOverlay);
-                addOverlayToMenu(
-                    'Logical data movement volume', MemoryVolumeOverlay
-                );
+                // Register overlays that are turned on by default.
+                this.overlay_manager.register_overlay(LogicalGroupOverlay);
+                addOverlayToMenu('Logical groups', LogicalGroupOverlay, true);
+
+                // Add overlays that are turned off by default.
+                addOverlayToMenu('Storage locations', MemoryLocationOverlay, false);
+                addOverlayToMenu('Logical data movement volume', MemoryVolumeOverlay, false);
+                
+                addOverlayToMenu('AvgParallelismOverlay', AvgParallelismOverlay, false);
+                addOverlayToMenu('DepthOverlay', DepthOverlay, false);
+                addOverlayToMenu('OperationalIntensityOverlay', OperationalIntensityOverlay, false);
+                addOverlayToMenu('RuntimeMicroSecondsOverlay', RuntimeMicroSecondsOverlay, false);
+                addOverlayToMenu('SimulatedOperationalIntensityOverlay', SimulatedOperationalIntensityOverlay, false);
+                addOverlayToMenu('StaticFlopsOverlay', StaticFlopsOverlay, false);
             }
 
             // Zoom to fit.

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -14,12 +14,6 @@ import {
     JsonSDFGState,
     MemoryLocationOverlay,
     MemoryVolumeOverlay,
-    AvgParallelismOverlay,
-    DepthOverlay,
-    OperationalIntensityOverlay,
-    RuntimeMicroSecondsOverlay,
-    SimulatedOperationalIntensityOverlay,
-    StaticFlopsOverlay,
     ModeButtons,
     Point2D,
     SDFVTooltipFunc,
@@ -589,13 +583,6 @@ export class SDFGRenderer extends EventEmitter {
                 // Add overlays that are turned off by default.
                 addOverlayToMenu('Storage locations', MemoryLocationOverlay, false);
                 addOverlayToMenu('Logical data movement volume', MemoryVolumeOverlay, false);
-                
-                addOverlayToMenu('AvgParallelismOverlay', AvgParallelismOverlay, false);
-                addOverlayToMenu('DepthOverlay', DepthOverlay, false);
-                addOverlayToMenu('OperationalIntensityOverlay', OperationalIntensityOverlay, false);
-                addOverlayToMenu('RuntimeMicroSecondsOverlay', RuntimeMicroSecondsOverlay, false);
-                addOverlayToMenu('SimulatedOperationalIntensityOverlay', SimulatedOperationalIntensityOverlay, false);
-                addOverlayToMenu('StaticFlopsOverlay', StaticFlopsOverlay, false);
             }
 
             // Zoom to fit.

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -223,8 +223,83 @@ export class SDFGElement {
         const ppp = canvas_manager?.points_per_pixel();
         if (!(ctx as any).lod || (ppp && ppp < SDFV.EDGE_LOD)) {
             const topleft = this.topleft();
+            ctx.strokeStyle = this.strokeStyle(renderer);
+            ctx.fillStyle = ctx.strokeStyle;
+            
+            function draw_summary_symbol(ctx: CanvasRenderingContext2D,
+                min_connector_x: number, max_connector_x: number,
+                horizontal_line_level: number, draw_arrows_above_line: boolean
+            ): void {
+
+                // Draw horizontal line
+                ctx.beginPath();
+                ctx.moveTo(min_connector_x, horizontal_line_level);
+                ctx.lineTo(max_connector_x, horizontal_line_level);
+                ctx.closePath();
+                ctx.stroke();
+
+                // Draw left arrow
+                const middle_of_line = (min_connector_x + max_connector_x) / 2;
+                const left_arrow_x = middle_of_line - 10;
+                const righ_arrow_x = middle_of_line + 10;
+                let arrow_start_y = horizontal_line_level + 2;
+                let arrow_end_y = horizontal_line_level + 8;
+                if (draw_arrows_above_line) {
+                    arrow_start_y = horizontal_line_level - 10;
+                    arrow_end_y = horizontal_line_level - 4;
+                }
+                const dot_height = (arrow_start_y + arrow_end_y) / 2;
+                // Arrow line
+                ctx.beginPath();
+                ctx.moveTo(left_arrow_x, arrow_start_y);
+                ctx.lineTo(left_arrow_x, arrow_end_y);
+                ctx.closePath();
+                ctx.stroke();
+                // Arrow head
+                ctx.beginPath();
+                ctx.moveTo(left_arrow_x, arrow_end_y + 2);
+                ctx.lineTo(left_arrow_x - 2, arrow_end_y);
+                ctx.lineTo(left_arrow_x + 2, arrow_end_y);
+                ctx.lineTo(left_arrow_x, arrow_end_y + 2);
+                ctx.closePath();
+                ctx.fill();
+                
+                // 3 dots
+                ctx.beginPath();
+                ctx.moveTo(middle_of_line - 5, dot_height)
+                ctx.lineTo(middle_of_line - 4, dot_height)
+                ctx.closePath();
+                ctx.stroke();
+                ctx.beginPath();
+                ctx.moveTo(middle_of_line - 0.5, dot_height)
+                ctx.lineTo(middle_of_line + 0.5, dot_height)
+                ctx.closePath();
+                ctx.stroke();
+                ctx.beginPath();
+                ctx.moveTo(middle_of_line + 4, dot_height)
+                ctx.lineTo(middle_of_line + 5, dot_height)
+                ctx.closePath();
+                ctx.stroke();
+
+                // Draw right arrow
+                // Arrow line
+                ctx.beginPath();
+                ctx.moveTo(righ_arrow_x, arrow_start_y);
+                ctx.lineTo(righ_arrow_x, arrow_end_y);
+                ctx.closePath();
+                ctx.stroke();
+                // Arrow head
+                ctx.beginPath();
+                ctx.moveTo(righ_arrow_x, arrow_end_y + 2);
+                ctx.lineTo(righ_arrow_x - 2, arrow_end_y);
+                ctx.lineTo(righ_arrow_x + 2, arrow_end_y);
+                ctx.lineTo(righ_arrow_x, arrow_end_y + 2);
+                ctx.closePath();
+                ctx.fill();
+            }
     
             if (this.summarise_in_edges) {
+                // Find the left most and right most connector coordinates
                 if (this.in_connectors.length > 0) {
                     let min_connector_x = Number.MAX_SAFE_INTEGER;
                     let max_connector_x = Number.MIN_SAFE_INTEGER;
@@ -235,16 +310,16 @@ export class SDFGElement {
                         if (c.x > max_connector_x) {
                             max_connector_x = c.x;
                         }
-                    })
-                    ctx.beginPath();
-                    ctx.moveTo(min_connector_x, topleft.y - 12);
-                    ctx.lineTo(max_connector_x, topleft.y - 12);
-                    ctx.closePath();
-                    ctx.strokeStyle = this.strokeStyle(renderer);
-                    ctx.stroke();
+                    });
+
+                    // Draw the summary symbol above the node
+                    draw_summary_symbol(ctx, 
+                        min_connector_x, max_connector_x, 
+                        topleft.y - 12, true);
                 }
             }
             if (this.summarise_out_edges) {
+                // Find the left most and right most connector coordinates
                 if (this.out_connectors.length > 0) {
                     let min_connector_x = Number.MAX_SAFE_INTEGER;
                     let max_connector_x = Number.MIN_SAFE_INTEGER;
@@ -255,13 +330,12 @@ export class SDFGElement {
                         if (c.x > max_connector_x) {
                             max_connector_x = c.x;
                         }
-                    })
-                    ctx.beginPath();
-                    ctx.moveTo(min_connector_x, topleft.y + this.height + 12);
-                    ctx.lineTo(max_connector_x, topleft.y + this.height + 12);
-                    ctx.closePath();
-                    ctx.strokeStyle = this.strokeStyle(renderer);
-                    ctx.stroke();
+                    });
+                    
+                    // Draw the summary symbol below the node
+                    draw_summary_symbol(ctx, 
+                        min_connector_x, max_connector_x, 
+                        topleft.y + this.height + 12, false);
                 }
             }
         }
@@ -2231,8 +2305,6 @@ export class Tasklet extends SDFGNode {
         const canvas_manager = renderer.get_canvas_manager();
         if (!canvas_manager)
             return;
-
-        this.draw_edge_summary(renderer, ctx);
 
         const topleft = this.topleft();
         drawOctagon(ctx, topleft, this.width, this.height);

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -2780,9 +2780,8 @@ export function drawStateContents(
 
         // Simple draw for non-collapsed NestedSDFGs
         if (node instanceof NestedSDFG && !node.data.node.attributes.is_collapsed) {
-            if (lod && (
-                Math.sqrt(node.height * node.width) / ppp
-            ) < SDFV.STATE_LOD) {
+            const nodeppp = Math.sqrt(node.width * node.height) / ppp;
+            if (lod && nodeppp < SDFV.STATE_LOD) {
                 node.simple_draw(renderer, ctx, mousePos);
                 node.debug_draw(renderer, ctx);
                 continue;

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -60,8 +60,8 @@ export class SDFGElement {
     // These two fields get set in the layouter, depending on the number of in/out_connectors
     // of a node. They also get toggled in the mousehandler when the hover status changes.
     // Currently only used for NestedSDFGs and ScopeNodes.
-    public summarise_in_edges: boolean = false;
-    public summarise_out_edges: boolean = false;
+    public summarize_in_edges: boolean = false;
+    public summarize_out_edges: boolean = false;
     // Used in draw_edge_summary to decide if edge summary is applicable. Set in the layouter
     // only for NestedSDFGs and ScopeNodes. This prevents the summary to get toggled on
     // by the mousehandler when it is not applicable.
@@ -304,7 +304,7 @@ export class SDFGElement {
                 ctx.fill();
             }
     
-            if (this.summarise_in_edges && this.in_summary_has_effect) {
+            if (this.summarize_in_edges && this.in_summary_has_effect) {
                 // Find the left most and right most connector coordinates
                 if (this.in_connectors.length > 0) {
                     let min_connector_x = Number.MAX_SAFE_INTEGER;
@@ -324,7 +324,7 @@ export class SDFGElement {
                         topleft.y - 8, true);
                 }
             }
-            if (this.summarise_out_edges && this.out_summary_has_effect) {
+            if (this.summarize_out_edges && this.out_summary_has_effect) {
                 // Find the left most and right most connector coordinates
                 if (this.out_connectors.length > 0) {
                     let min_connector_x = Number.MAX_SAFE_INTEGER;
@@ -1229,7 +1229,7 @@ export class Memlet extends Edge {
 
     // Currently used for Memlets to decide if they need to be drawn or not.
     // Set in the layouter.
-    public summarised: boolean = false;
+    public summarized: boolean = false;
 
     public create_arrow_line(ctx: CanvasRenderingContext2D): void {
         // Draw memlet edges with quadratic curves through the arrow points.
@@ -2712,8 +2712,8 @@ function batchedDrawEdges(
             deferredEdges.push(edge);
             return;
         }
-        // Dont draw if Memlet is summarised
-        else if (edge instanceof Memlet && edge.summarised) {
+        // Dont draw if Memlet is summarized
+        else if (edge instanceof Memlet && edge.summarized) {
             return;
         }
 

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -58,9 +58,15 @@ export class SDFGElement {
     // Used to draw edge summary instead of all edges separately.
     // Helps with rendering performance when too many edges would be drawn on the screen.
     // These two fields get set in the layouter, depending on the number of in/out_connectors
-    // of a node.
+    // of a node. They also get toggled in the mousehandler when the hover status changes.
+    // Currently only used for NestedSDFGs and ScopeNodes.
     public summarise_in_edges: boolean = false;
     public summarise_out_edges: boolean = false;
+    // Used in draw_edge_summary to decide if edge summary is applicable. Set in the layouter
+    // only for NestedSDFGs and ScopeNodes. This prevents the summary to get toggled on
+    // by the mousehandler when it is not applicable.
+    public in_summary_has_effect: boolean = false;
+    public out_summary_has_effect: boolean = false;
 
     public x: number = 0;
     public y: number = 0;
@@ -298,7 +304,7 @@ export class SDFGElement {
                 ctx.fill();
             }
     
-            if (this.summarise_in_edges) {
+            if (this.summarise_in_edges && this.in_summary_has_effect) {
                 // Find the left most and right most connector coordinates
                 if (this.in_connectors.length > 0) {
                     let min_connector_x = Number.MAX_SAFE_INTEGER;
@@ -318,7 +324,7 @@ export class SDFGElement {
                         topleft.y - 8, true);
                 }
             }
-            if (this.summarise_out_edges) {
+            if (this.summarise_out_edges && this.out_summary_has_effect) {
                 // Find the left most and right most connector coordinates
                 if (this.out_connectors.length > 0) {
                     let min_connector_x = Number.MAX_SAFE_INTEGER;

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -2624,7 +2624,8 @@ export function drawStateContents(
         ))
             continue;
 
-        if (node instanceof NestedSDFG) {
+        // Simple draw for non-collapsed NestedSDFGs
+        if (node instanceof NestedSDFG && !node.data.node.attributes.is_collapsed) {
             if (lod && (
                 Math.sqrt(node.height * node.width) / ppp
             ) < SDFV.STATE_LOD) {
@@ -2633,6 +2634,7 @@ export function drawStateContents(
                 continue;
             }
         } else {
+            // Simple draw node
             if (lod && ppp > SDFV.NODE_LOD) {
                 node.simple_draw(renderer, ctx, mousePos);
                 node.debug_draw(renderer, ctx);

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -1498,7 +1498,7 @@ export class InterstateEdge extends Edge {
         const ppp = renderer.get_canvas_manager()?.points_per_pixel();
         if (ppp === undefined)
             return;
-        if ((ctx as any).lod && ppp >= SDFV.SCOPE_LOD)
+        if ((ctx as any).lod && ppp > SDFV.SCOPE_LOD)
             return;
 
         const labelLines = [];
@@ -3024,7 +3024,7 @@ export function drawAdaptiveText(
     if (ppp === undefined)
         return;
 
-    const is_far: boolean = (ctx as any).lod && ppp >= ppp_thres;
+    const is_far: boolean = (ctx as any).lod && ppp > ppp_thres;
     const label = is_far ? far_text : close_text;
 
     let font_size = Math.min(

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -231,12 +231,12 @@ export class SDFGElement {
                 horizontal_line_level: number, draw_arrows_above_line: boolean
             ): void {
 
-                // Draw horizontal line
-                ctx.beginPath();
-                ctx.moveTo(min_connector_x, horizontal_line_level);
-                ctx.lineTo(max_connector_x, horizontal_line_level);
-                ctx.closePath();
-                ctx.stroke();
+                // Draw horizontal line (looks better without)
+                // ctx.beginPath();
+                // ctx.moveTo(min_connector_x, horizontal_line_level);
+                // ctx.lineTo(max_connector_x, horizontal_line_level);
+                // ctx.closePath();
+                // ctx.stroke();
 
                 // Draw left arrow
                 const middle_of_line = (min_connector_x + max_connector_x) / 2;
@@ -315,7 +315,7 @@ export class SDFGElement {
                     // Draw the summary symbol above the node
                     draw_summary_symbol(ctx, 
                         min_connector_x, max_connector_x, 
-                        topleft.y - 12, true);
+                        topleft.y - 8, true);
                 }
             }
             if (this.summarise_out_edges) {
@@ -335,7 +335,7 @@ export class SDFGElement {
                     // Draw the summary symbol below the node
                     draw_summary_symbol(ctx, 
                         min_connector_x, max_connector_x, 
-                        topleft.y + this.height + 12, false);
+                        topleft.y + this.height + 8, false);
                 }
             }
         }

--- a/src/sdfv.ts
+++ b/src/sdfv.ts
@@ -55,7 +55,10 @@ export class SDFV {
     public static NODE_LOD: number = 5.0; // 5.0
     // Points-per-pixel threshold for not drawing node text.
     public static TEXT_LOD: number = 1.5; // 1.5
-    // Pixel threshold for not drawing state contents.
+
+    // Pixel threshold for not drawing State and NestedSDFG contents.
+    // This threshold behaves differently than the ones above. The State's size is compared to this 
+    // threshold and if the State is smaller its contents are not drawn in the renderer.
     public static STATE_LOD: number = 100; // 100
 
     public static DEFAULT_CANVAS_FONTSIZE: number = 10;

--- a/src/sdfv.ts
+++ b/src/sdfv.ts
@@ -67,8 +67,14 @@ export class SDFV {
     public static STATE_LOD: number = 100; // 100
 
     public static DEFAULT_CANVAS_FONTSIZE: number = 10;
-    public static DEFAULT_MAX_FONTSIZE: number = 20; // 50
+    public static DEFAULT_MAX_FONTSIZE: number = 20; // 20
     public static DEFAULT_FAR_FONT_MULTIPLIER: number = 16; // 16
+
+    // Dagre layout options.
+    // Separation between ranks (vertically) in pixels.
+    public static RANKSEP: number = 70; // Dagre default: 50
+    // Separation between nodes (horizontally) in pixels.
+    public static NODESEP: number = 20; // Dagre default: 50
 
     protected renderer: SDFGRenderer | null = null;
     protected localViewRenderer: LViewRenderer | null = null;

--- a/src/sdfv.ts
+++ b/src/sdfv.ts
@@ -250,10 +250,12 @@ export class SDFV {
 
         if (elem instanceof Memlet && elem.parent_id && elem.id) {
             const sdfg_edge = elem.parentElem?.data.state.edges[elem.id];
-            contents.append($('<h4>', {
-                html: 'Connectors: ' + sdfg_edge.src_connector + ' &rarr; ' +
-                    sdfg_edge.dst_connector,
-            }));
+            if (sdfg_edge) {
+                contents.append($('<h4>', {
+                    html: 'Connectors: ' + sdfg_edge.src_connector + ' &rarr; ' +
+                        sdfg_edge.dst_connector,
+                }));
+            }
         }
         contents.append($('<hr>'));
 

--- a/src/sdfv.ts
+++ b/src/sdfv.ts
@@ -248,14 +248,11 @@ export class SDFV {
         const contents = $(contentsRaw);
         contents.html('');
 
-        if (elem instanceof Memlet && elem.parent_id && elem.id) {
-            const sdfg_edge = elem.parentElem?.data.state.edges[elem.id];
-            if (sdfg_edge) {
-                contents.append($('<h4>', {
-                    html: 'Connectors: ' + sdfg_edge.src_connector + ' &rarr; ' +
-                        sdfg_edge.dst_connector,
-                }));
-            }
+        if (elem instanceof Memlet) {
+            contents.append($('<p>', {
+                html: 'Connectors: ' + elem.src_connector + ' &rarr; ' +
+                    elem.dst_connector,
+            }));
         }
         contents.append($('<hr>'));
 

--- a/src/sdfv.ts
+++ b/src/sdfv.ts
@@ -528,7 +528,7 @@ function file_read_complete(sdfv: SDFV): void {
             sdfv.get_renderer()?.destroy();
             sdfv.set_renderer(new SDFGRenderer(sdfv, sdfg, container, mouse_event));
             sdfv.close_menu();
-        }, 20);
+        }, 10);
     }
 }
 


### PR DESCRIPTION
- Sorting connectors so that edges don't intertwine
- Summarize edges with a symbol in cases where too many are rendered
- Hovering over nodes shows all attached edges
- Adjusted nodesep and ranksep
- Fixed error when selecting memlet
- Added Shift+Rightclick to expand/collapse
- Added Ctrl+Scroll verticalscroll in zoom mode
- Various Overlay LOD threshold adjustments

## Before
![edges_unsorted](https://github.com/spcl/dace-webclient/assets/104513844/96bf4334-fa71-497f-b7ad-9a6b5cae893d)

## Sorted
![edges_sorted](https://github.com/spcl/dace-webclient/assets/104513844/161a5716-06a1-4377-9a46-37a5552efeab)

## Summarized
![edges_summarised](https://github.com/spcl/dace-webclient/assets/104513844/46667d30-2878-4463-b14d-8d0cdaa2bb01)
