### PR TITLE
Display named regions and function call regions

### DIFF
--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -4859,6 +4859,8 @@ function relayoutSDFGBlock(
     switch (block.type) {
         case SDFGElementType.LoopRegion:
         case SDFGElementType.ControlFlowRegion:
+        case SDFGElementType.NamedRegion:
+        case SDFGElementType.FunctionCallRegion:
             return relayoutStateMachine(
                 ctx, block as JsonSDFGControlFlowRegion, sdfg, sdfgList,
                 stateParentList, omitAccessNodes, parent

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -45,6 +45,8 @@ export enum SDFGElementType {
     ControlFlowBlock = 'ControlFlowBlock',
     ControlFlowRegion = 'ControlFlowRegion',
     LoopRegion = 'LoopRegion',
+    NamedRegion = 'NamedRegion',
+    FunctionCallRegion = 'FunctionCallRegion'
 }
 
 function draw_summary_symbol(
@@ -648,6 +650,10 @@ export class ControlFlowRegion extends ControlFlowBlock {
     }
 
 }
+
+export class NamedRegion extends ControlFlowRegion {}
+
+export class FunctionCallRegion extends ControlFlowRegion {}
 
 export class State extends BasicBlock {
 
@@ -3404,4 +3410,6 @@ export const SDFGElements: { [name: string]: typeof SDFGElement } = {
     BreakBlock,
     ContinueBlock,
     ReturnBlock,
+    NamedRegion,
+    FunctionCallRegion
 };


### PR DESCRIPTION
This is part of my GSoC project.
This PR will display named regions and function call regions as control flow region.

![function_call](https://github.com/user-attachments/assets/4be78a5d-3f4f-4eda-a6ab-9a98a0e25f29)
![named_region](https://github.com/user-attachments/assets/63da7202-e534-46d7-b3ef-321f9a0ab0ae)
