### PR TITLE
Fix behavior locking panning to viewport

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@spcl/sdfv",
-    "version": "1.2.9",
+    "version": "1.2.10",
     "description": "A standalone viewer for SDFGs",
     "homepage": "https://github.com/spcl/dace-webclient",
     "main": "out/index.js",

--- a/src/settings_manifest.json
+++ b/src/settings_manifest.json
@@ -81,12 +81,17 @@
                 }
             },
             "mouse": {
-                "label": "Mouse",
+                "label": "Navigation",
                 "settings": {
                     "useVerticalScrollNavigation": {
                         "label": "Use vertical scroll navigation (binds zoom to Ctrl + scroll)",
                         "type": "boolean",
                         "default": false
+                    },
+                    "bindToViewport": {
+                        "label": "Restrict panning to ensure the graph is always visible",
+                        "type": "boolean",
+                        "default": true
                     }
                 }
             },


### PR DESCRIPTION
This PR fixes issues with the functionality to restrict panning, keeping the graph in view.
The feature has been changed as follows:
1. A config toggle allows disabling the pan restriction entirely
2. The pan restriction is no longer based on the minimap. Basing it on the minimap leads to issues when the minimap is disabled or the viewer is initialized with the minimap already disabled, which is primarily an issue in embedded scenarios or VSCode.
3. The pan restriction now no longer aims to keep the graph 'centered' in the viewport, but rather stops panning when the graph is about to exit the viewport entirely. This allows for a significantly higher degree of freedom and basically unnoticeably limits panning, while making sure the graph does not end up far out of view.

This is an alternative to and thus would close https://github.com/spcl/dace-webclient/pull/155.
Closes https://github.com/spcl/dace-webclient/issues/157.