### PR TITLE
Reorient view during relayout based on visible elements

### DIFF
--- a/src/renderer/canvas_manager.ts
+++ b/src/renderer/canvas_manager.ts
@@ -382,10 +382,10 @@ export class CanvasManager {
         if (parent_graph && !(el instanceof Edge)) {
             // Find all the edges connected to the moving node
             parent_graph.outEdges(el.id.toString())?.forEach(edge_id => {
-                out_edges.push(parent_graph.edge(edge_id));
+                out_edges.push(parent_graph!.edge(edge_id));
             });
             parent_graph.inEdges(el.id.toString())?.forEach(edge_id => {
-                in_edges.push(parent_graph.edge(edge_id));
+                in_edges.push(parent_graph!.edge(edge_id));
             });
         }
 

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -2877,18 +2877,18 @@ export class SDFGRenderer extends EventEmitter {
 
         // Toggle collapsed state
         if (foreground_elem.COLLAPSIBLE) {
-            if ('is_collapsed' in sdfg_elem.attributes) {
-                sdfg_elem.attributes.is_collapsed =
-                    !sdfg_elem.attributes.is_collapsed;
-            } else {
-                sdfg_elem.attributes['is_collapsed'] = true;
-            }
-
             this.emit('collapse_state_changed');
 
             // Re-layout SDFG
             this.add_loading_animation();
             setTimeout(() => {
+                if ('is_collapsed' in sdfg_elem.attributes) {
+                    sdfg_elem.attributes.is_collapsed =
+                        !sdfg_elem.attributes.is_collapsed;
+                } else {
+                    sdfg_elem.attributes['is_collapsed'] = true;
+                }
+
                 this.relayout(foreground_elem);
                 this.draw_async();
             }, 10);

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1246,6 +1246,9 @@ export class SDFGRenderer extends EventEmitter {
         if (!this.ctx)
             throw new Error('No context found while performing layouting');
 
+        // Collect currently-visible elements for reorientation
+        let elements = this.getVisibleElements();
+
         for (const cfgId in this.cfgList) {
             this.cfgList[cfgId].graph = null;
             this.cfgList[cfgId].nsdfgNode = null;
@@ -1259,6 +1262,10 @@ export class SDFGRenderer extends EventEmitter {
         for (const bId of this.graph.nodes())
             topLevelBlocks.push(this.graph.node(bId));
         this.graphBoundingBox = boundingBox(topLevelBlocks);
+
+        // Reorient view based on an approximate set of visible elements
+        this.zoom_to_view(elements, false, 0, false);
+
         this.onresize();
 
         this.update_fast_memlet_lookup();
@@ -1378,7 +1385,7 @@ export class SDFGRenderer extends EventEmitter {
     // Change translation and scale such that the chosen elements
     // (or entire graph if null) is in view
     public zoom_to_view(
-        elements: any = null, animate: boolean = true, padding?: number
+        elements: any = null, animate: boolean = true, padding?: number, redraw: boolean = false
     ): void {
         if (!elements || elements.length === 0) {
             elements = this.graph?.nodes().map(x => this.graph?.node(x));
@@ -1400,7 +1407,9 @@ export class SDFGRenderer extends EventEmitter {
         const bb = boundingBox(elements, paddingAbs);
         this.canvas_manager?.set_view(bb, animate);
 
-        this.draw_async();
+        if (redraw) {
+            this.draw_async();
+        }
     }
 
     public zoomToFitWidth(): void {

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -1399,8 +1399,8 @@ export abstract class Edge extends SDFGElement {
                 };
 
                 // Check if the two rectangles intersect
-                if (r.x + r.w >= x && r.x <= x+w &&
-                    r.y + r.h >= y && r.y <= y+h)
+                if (r.x + r.w >= x && r.x <= x + w &&
+                    r.y + r.h >= y && r.y <= y + h)
                     return true;
             }
             return false;
@@ -2115,9 +2115,9 @@ export class ScopeNode extends SDFGNode {
                 SDFV.DEFAULT_MAX_FONTSIZE, 0.7,
                 SDFV.DEFAULT_FAR_FONT_MULTIPLIER, true,
                 TextVAlign.BOTTOM, TextHAlign.RIGHT, {
-                    bottom: 2.0,
-                    right: this.height,
-                }
+                bottom: 2.0,
+                right: this.height,
+            }
             );
         }
     }
@@ -3350,7 +3350,7 @@ export function drawOctagon(
 export function drawEllipse(
     ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number
 ): void {
-    ctx.ellipse(x+w/2, y+h/2, w/2, h/2, 0, 0, 2 * Math.PI);
+    ctx.ellipse(x + w / 2, y + h / 2, w / 2, h / 2, 0, 0, 2 * Math.PI);
 }
 
 export function drawTrapezoid(

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -208,6 +208,12 @@ export class SDFGElement {
         return this.data.label;
     }
 
+    public guid(): string {
+        // If GUID does not exist, fall back to element ID
+        return this.cfg?.cfg_list_id + '/' + (
+            this.parent_id ?? -1) + '/' + this.id;
+    }
+
     // Text used for matching the element during a search
     public text_for_find(): string {
         return this.label();
@@ -1810,6 +1816,10 @@ export class Connector extends SDFGElement {
     public custom_label: string | null = null;
     public linkedElem?: SDFGElement;
     public connectorType: 'in' | 'out' = 'in';
+
+    public guid(): string {
+        return '';  // Connectors have no GUID
+    }
 
     public draw(
         renderer: SDFGRenderer, ctx: CanvasRenderingContext2D,

--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -2125,9 +2125,9 @@ export class ScopeNode extends SDFGNode {
                 SDFV.DEFAULT_MAX_FONTSIZE, 0.7,
                 SDFV.DEFAULT_FAR_FONT_MULTIPLIER, true,
                 TextVAlign.BOTTOM, TextHAlign.RIGHT, {
-                bottom: 2.0,
-                right: this.height,
-            }
+                    bottom: 2.0,
+                    right: this.height,
+                }
             );
         }
     }


### PR DESCRIPTION
Relayout now tries to keep track of the visible elements from before relayouting. This should allow more fluid transition when collapsing elements. The heuristic condition is: every _node_ that was _entirely_ visible before the relayouting should still be visible after it. If they are all already visible, no changes are made to the view (we would like to minimize involuntary view changes as much as possible). 
Additionally, if a specific element instigated the change (i.e., a node was collapsed), it will also be included in the nodes to view.



The PR also fixes a visual artifact introduced wherein collapsed nodes still appear for a few frames with their old coordinates, which results in a badly-drawn graph.