### PR TITLE
Make memlet label more descriptive

### DIFF
--- a/src/renderer/renderer_elements.ts
+++ b/src/renderer/renderer_elements.ts
@@ -1702,9 +1702,16 @@ export class Memlet extends Edge {
         contents += sdfg_property_to_string(attr.subset, dsettings);
 
         if (attr.other_subset) {
-            contents += ' -> ' + sdfg_property_to_string(
-                attr.other_subset, dsettings
-            );
+            // TODO: Obtain other data name, if possible
+            if (attr.is_data_src) {
+                contents += ' -> ' + sdfg_property_to_string(
+                    attr.other_subset, dsettings
+                );
+            } else {
+                contents = sdfg_property_to_string(
+                    attr.other_subset, dsettings
+                ) + ' -> ' + contents;
+            }
         }
 
         if (attr.wcr) {


### PR DESCRIPTION
If the directionality of the memlet is different, print the label inverted. Companion PR to https://github.com/spcl/dace/pull/1680